### PR TITLE
Change get-started to installation

### DIFF
--- a/src/pug/docs/index.pug
+++ b/src/pug/docs/index.pug
@@ -10,6 +10,6 @@ block content
     +improveDocsLink
     h1 Framework7 Documentation
     p Start creating awesome iOS & Android apps with Framework7.
-    p Before you start we highly recommend you to read <a href="get-started.html">Getting Started</a> guide about how to download/install Framework7 and look at its basic layout.
+    p Before you start we highly recommend you to read <a href="installation.html">Installation</a> guide about how to download/install Framework7 and look at its basic layout.
     p Framework7's learning curve is pretty easy. If you know HTML, CSS and a bit of JavaScript - you almost know how to create apps with Framework7.
     p So, let's start from basic <a href="app-layout.html">App HTML Layout</a>

--- a/src/pug/docs/index.pug
+++ b/src/pug/docs/index.pug
@@ -10,6 +10,6 @@ block content
     +improveDocsLink
     h1 Framework7 Documentation
     p Start creating awesome iOS & Android apps with Framework7.
-    p Before you start we highly recommend you to read <a href="installation.html">Installation</a> guide about how to download/install Framework7 and look at its basic layout.
+    p Before you start we highly recommend you to read the <a href="installation.html">Installation</a> guide about how to download/install Framework7 and look at its basic layout.
     p Framework7's learning curve is pretty easy. If you know HTML, CSS and a bit of JavaScript - you almost know how to create apps with Framework7.
     p So, let's start from basic <a href="app-layout.html">App HTML Layout</a>

--- a/src/pug/docs/index.pug
+++ b/src/pug/docs/index.pug
@@ -10,6 +10,6 @@ block content
     +improveDocsLink
     h1 Framework7 Documentation
     p Start creating awesome iOS & Android apps with Framework7.
-    p Before you start we highly recommend you to read the <a href="installation.html">Installation</a> guide about how to download/install Framework7 and look at its basic layout.
+    p Before you start we highly recommend you to read the <a href="installation.html">Installation</a> guide on how to download/install Framework7 and look at its basic layout.
     p Framework7's learning curve is pretty easy. If you know HTML, CSS and a bit of JavaScript - you almost know how to create apps with Framework7.
     p So, let's start from basic <a href="app-layout.html">App HTML Layout</a>


### PR DESCRIPTION
get-started.html is a 404 and installation.html most closely resembles the page's original purpose.
  