### PR TITLE
Issue in code example for "Control Popup With Links"

### DIFF
--- a/src/pug/docs/popup.pug
+++ b/src/pug/docs/popup.pug
@@ -242,9 +242,9 @@ block content
                     </div>
                   </div>
                 </div>
-              </div>
-              <div class="page-content">
-                ...
+                <div class="page-content">
+                  ...
+                </div>
               </div>
             </div>
             ...


### PR DESCRIPTION
I'm pretty sure the "page-content" element in this example should be nested inside the "page" element, right after the "navbar" element. In the current version the "page-content" element is directly inside the "view" element, outside and right after the "page" element.