### PR TITLE
Added Twitter cards

### DIFF
--- a/src/pug/_docs-template.pug
+++ b/src/pug/_docs-template.pug
@@ -7,6 +7,11 @@ html
     title=title
     meta(property="og:image", content="http://framework7.io/i/f7-banner.jpg")
     meta(name="viewport", content="width=device-width, viewport-fit=cover")
+    meta(name="twitter:card", content="summary")
+    meta(name="twitter:site", content="@framework7io")
+    meta(name="twitter:creator", content="@framework7io")
+    meta(name="twitter:title", content=title)
+    meta(name="twitter:image", content="https://avatars0.githubusercontent.com/u/31954178?s=200&v=4")
     if (includeF7Icons)
       link(rel="stylesheet" href=cdn + "/css/framework7-icons.css")
     link(rel="stylesheet", href=cdn + "/css/normalize.css")

--- a/src/pug/_internal-template.pug
+++ b/src/pug/_internal-template.pug
@@ -6,6 +6,11 @@ html
     title=title
     meta(property="og:image", content="http://framework7.io/i/f7-banner.jpg")
     meta(name="viewport", content="width=device-width, viewport-fit=cover")
+    meta(name="twitter:card", content="summary")
+    meta(name="twitter:site", content="@framework7io")
+    meta(name="twitter:creator", content="@framework7io")
+    meta(name="twitter:title", content=title)
+    meta(name="twitter:image", content="https://avatars0.githubusercontent.com/u/31954178?s=200&v=4")
     if (includeF7Icons)
       link(rel="stylesheet" href=cdn + "/css/framework7-icons.css")
     link(rel="stylesheet", href=cdn + "/css/normalize.css")

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -5,6 +5,12 @@ html
     title Framework7 - Full Featured Mobile HTML Framework For Building iOS & Android Apps
     meta(property="og:image", content=cdn + "/i/f7-banner.jpg")
     meta(name="viewport" content="width=device-width, viewport-fit=cover")
+    meta(name="twitter:card", content="summary")
+    meta(name="twitter:site", content="@framework7io")
+    meta(name="twitter:creator", content="@framework7io")
+    meta(name="twitter:title", content="Framework7")
+    meta(name="twitter:description", content="A free and open source mobile HTML framework to develop hybrid mobile apps or web apps with iOS & Android native look and feel")
+    meta(name="twitter:image", content="https://avatars0.githubusercontent.com/u/31954178?s=200&v=4")
     link(rel="stylesheet", href=cdn + "/css/normalize.css")
     link(rel="stylesheet", href=cdn + "/css/main.css")
     link(rel="shortcut icon" href="/i/favicon.png")


### PR DESCRIPTION
**Logo**
I used this url for the F7 logo:
https://avatars0.githubusercontent.com/u/31954178?s=200&v=4
You can change it to a different URL if you want.

**Description**
```
// TODO
// Generate dynamic description for each
// site so SEO and Twitter card attribute
// "description" gets optimized
```

**Preview**
A twitter card looks like this when a user posts a URL to F7 website:

![screen](https://user-images.githubusercontent.com/3787662/39864591-6757eaf0-544a-11e8-91f5-61010214a5dd.jpg)