### PR TITLE
Fix Dom7 link

### DIFF
--- a/src/pug/vue/vue-component-extensions.pug
+++ b/src/pug/vue/vue-component-extensions.pug
@@ -23,7 +23,7 @@ block content
           td Main Framework7's initialized instance. It allows you to use any of Framework7 APIs
         tr
           td this.$$<br>this.Dom7
-          td Access to built-in <a href="../docs/dom.html">Dom7</a> DOM library that utilizes most edge and high-performance methods for DOM manipulation
+          td Access to built-in <a href="../docs/dom7.html">Dom7</a> DOM library that utilizes most edge and high-performance methods for DOM manipulation
         tr
           td this.$device
           td Access to <a href="../docs/device.html">Device</a> utilities


### PR DESCRIPTION
Fix link to Dom7 documentation
Original: https://framework7.io/docs/dom.html
Fixed: https://framework7.io/docs/dom7.html