### PR TITLE
Shorten tile text Facebook community

### DIFF
--- a/src/pug/templates/templates.yml
+++ b/src/pug/templates/templates.yml
@@ -96,7 +96,7 @@ community:
 -
   title: Facebook API JavaScript SDK get all Albums and Photos
   icon:
-    text: Facebook API JavaScript SDK get all Albums and Photos
+    text: Get all Facebook Photos
     bgColor: '#3B5998'
     textColor: '#fff'
   author:


### PR DESCRIPTION
Just shortening the tile text for #181, as it felt too long and cut off on mobile.