### PR TITLE
Fix selector property from "input" to "inputEl"

### DIFF
--- a/src/pug/docs/calendar.pug
+++ b/src/pug/docs/calendar.pug
@@ -55,7 +55,7 @@ block content
     p For example:
     :code(lang="js")
           var calendar = app.calendar.create({
-              input: '#calendar-input'
+              inputEl: '#calendar-input'
           });
     h2 Calendar Parameters
     p Let's look on list of all available Calendar parameters:


### PR DESCRIPTION

# **Fix Wrong property name**
The element selector property name, as it was wrong, it should be `inputEl` but it has been written as `input`