### PR TITLE
[docs] Fix tiny typo

### DIFF
--- a/src/pug/docs/installation.pug
+++ b/src/pug/docs/installation.pug
@@ -51,7 +51,7 @@ block content
     :code(lang="js")
           import Framework7, { Device, Request } from 'framework7';
 
-          var app = new Framework({/*...*/});
+          var app = new Framework7({/*...*/});
 
           if (Device.ios) {
             Request.get('http://google.com');


### PR DESCRIPTION
```Framework``` >> ```Framework7```