### PR TITLE
Неправильный класс для toolbar

### DIFF
--- a/src/pug/docs/tabs.pug
+++ b/src/pug/docs/tabs.pug
@@ -108,7 +108,7 @@ block content
                   Tabbar for switching views-tabs. Should be a first child in Views.
                   Additional "toolbar-bottom-md" class is also required here for MD theme
                 -->
-                <div class="toolbar tabbar-labels toolbar-bottom-md">
+                <div class="toolbar tabbar toolbar-bottom-md">
                   <div class="toolbar-inner">
                     <a href="#view-home" class="tab-link tab-link-active">
                       <i class="icon icon-home"></i>


### PR DESCRIPTION
В данном примере нет labels, т.е. текста, только иконка.