### PR TITLE
Отсутствует класс

### DIFF
--- a/src/pug/docs/toolbar-tabbar.pug
+++ b/src/pug/docs/toolbar-tabbar.pug
@@ -405,7 +405,7 @@ block content
                   ...
               </div>
               <!-- Additional "tabbar-labels" class -->
-              <div class="toolbar tabbar-labels">
+              <div class="toolbar tabbar tabbar-labels">
                 <div class="toolbar-inner">
                   <a href="#tab-1" class="tab-link tab-link-active">
                     <!-- Different icons for iOS and MD themes -->


### PR DESCRIPTION
Согласно https://framework7.io/docs/toolbar-tabbar.html#tabbar-with-labels tabbar-labels добавляется к tabbar, а не заменяет его.