### PR TITLE
Неправильный тип аргумента

### DIFF
--- a/src/pug/docs/popover.pug
+++ b/src/pug/docs/popover.pug
@@ -221,7 +221,7 @@ block content
             ul.method-parameters
               li
                 span.parameter targetEl
-                |  - <span class="parameter-type">boolean</span> (by default <code>true</code>) - target element to set popover position around this element
+                |  - <span class="parameter-type">HTMLElement or string</span> - target element to set popover position around this element
               li
                 span.parameter animate
                 |  - <span class="parameter-type">boolean</span> (by default <code>true</code>) - defines whether it should be opened with animation


### PR DESCRIPTION
Должна быть строка или HTML-элемент. Если указано при создании popover'a, то будет перезапись. Если не указано и не указано также при создании popover'a, то popover не откроется.