### PR TITLE
Spelling mistake corrected

### DIFF
--- a/src/pug/react/installation.pug
+++ b/src/pug/react/installation.pug
@@ -17,7 +17,7 @@ block content
     p The most recommended way to start with new Framework7 app is to use <a href="/cli/">Framework7 CLI</a>, it provides most complete amount of combinations with different templates, target devices/platforms, frameworks and some of best practices.
 
     h2 Ready To Use Templates
-    p You can also check the #[a(href="/templates/") starter app templates and tools] section to strat straight away from some pre-setup app.
+    p You can also check the #[a(href="/templates/") starter app templates and tools] section to start straight away from some pre-setup app.
 
     h2 Manual Installation
     h4 1. Install Framework7

--- a/src/pug/vue/installation.pug
+++ b/src/pug/vue/installation.pug
@@ -17,7 +17,7 @@ block content
     p The most recommended way to start with new Framework7 app is to use <a href="/cli/">Framework7 CLI</a>, it provides most complete amount of combinations with different templates, target devices/platforms, frameworks and some of best practices.
 
     h2 Ready To Use Templates
-    p You can also check the #[a(href="/templates/") starter app templates and tools] section to strat straight away from some pre-setup app.
+    p You can also check the #[a(href="/templates/") starter app templates and tools] section to start straight away from some pre-setup app.
 
     h2 Manual Installation
     h4 1. Install Framework7


### PR DESCRIPTION
Spelling mistake corrected under Ready To Use Templates, "section to strat" to "section to start" (also in the Vue and React docs).