### PR TITLE
Updated Installation Section for Framework7

### DIFF
--- a/src/pug/docs/installation.pug
+++ b/src/pug/docs/installation.pug
@@ -30,6 +30,15 @@ block content
         p We can also install Framework7 from NPM:
         :code
           $ npm install framework7
-    p From the downloaded Core package we will need files from <code>css</code> and <code>js</code> folders
+        p From the downloaded Core package we will need files from <code>css</code> and <code>js</code> folders
+      li
+        p
+          b Install From CDN
+        p We can also install Framework7 from <a href="https://pagecdn.com/lib/framework7">Framework7 CDN</a>:
+        :code
+          <link rel="stylesheet" href="https://pagecdn.io/lib/framework7/4.4.6/css/framework7.min.css" integrity="sha256-IIZ1gn9XmIDyaJH4Y76W0xWOVnx11SZ0MhvHNUXP7gE=" crossorigin="anonymous">
+          <script src="https://pagecdn.io/lib/framework7/4.4.6/js/framework7.min.js" integrity="sha256-1BEGPEbJe1YvA121EjT7B05V8A4L0RMEO4semD5bXV0=" crossorigin="anonymous"></script>
+        
+        
 
 


### PR DESCRIPTION
Since Framework7 is a big framework, it might be fruitful to refer to CDN links that can help deliver the Framework from browser cache.

PageCDN uses brotli-11 compression that reduces **framework7.min.js file size to 47 KB** and **framework7.min.css file size to 19 KB** only. In addition, **immutable caching** is enabled by default to optimize content delivery a little more aggressively. This will make this CDN a valuable addition to the documentation.

Ref: [Framework7 CDN](https://pagecdn.com/lib/framework7) by PageCDN.