### PR TITLE
Fix kitchen-sink mobile preview link

### DIFF
--- a/src/pug/docs/kitchen-sink.pug
+++ b/src/pug/docs/kitchen-sink.pug
@@ -11,7 +11,7 @@ block content
     +improveDocsLink
     h1 Kitchen Sink
     ul.docs-index
-    .with-device(data-device-preview="../kitchen-sink/core/index.html?theme=ios")
+    .with-device(data-device-preview="../kitchen-sink/core/index.html")
       p Framework7 Kitchen Sink is a great place to get started, it has a lot of examples for all Framework7 components and covers most of aspects.
       p It is recommended to use Kitchen Sink as a reference during development.
       h2 Source Code

--- a/src/pug/react/kitchen-sink.pug
+++ b/src/pug/react/kitchen-sink.pug
@@ -12,7 +12,7 @@ block content
     +improveDocsLink
     h1 Kitchen Sink
     ul.docs-index
-    .with-device(data-device-preview="../kitchen-sink/react/index.html?theme=ios")
+    .with-device(data-device-preview="../kitchen-sink/react/index.html")
       p Framework7-React Kitchen Sink is a great place to get started, it has a lot of examples for all Framework7-React components and covers most of aspects.
       p It is recommended to use it as a reference during development.
       h2 Source Code

--- a/src/pug/vue/kitchen-sink.pug
+++ b/src/pug/vue/kitchen-sink.pug
@@ -12,7 +12,7 @@ block content
     +improveDocsLink
     h1 Kitchen Sink
     ul.docs-index
-    .with-device(data-device-preview="../kitchen-sink/vue/index.html?theme=ios")
+    .with-device(data-device-preview="../kitchen-sink/vue/index.html")
       p Framework7-Vue Kitchen Sink is a great place to get started, it has a lot of examples for all Framework7-Vue components and covers most of aspects.
       p It is recommended to use it as a reference during development.
       h2 Source Code


### PR DESCRIPTION
In mobile version wrong base_url for link preview. It contains `?theme=os` query params.

Example:
![wrong_base_url](https://user-images.githubusercontent.com/2877000/62796083-8f379e80-bad8-11e9-9f5a-f893bca23b30.gif)
