### PR TITLE
Fix: No Icons shown in the ios preview of FAB Buttons in the Docs

### DIFF
--- a/src/pug/docs-demos/core/chips.pug
+++ b/src/pug/docs-demos/core/chips.pug
@@ -49,7 +49,7 @@ block content
         <div class="block block-strong">
           <div class="chip">
             <div class="chip-media bg-color-blue">
-              <i class="icon f7-icons if-not-md">add_round</i>
+              <i class="icon f7-icons if-not-md">plus_circle</i>
               <i class="icon material-icons md-only">add_circle</i>
             </div>
             <div class="chip-label">Add Contact</div>

--- a/src/pug/docs-demos/core/floating-action-button.pug
+++ b/src/pug/docs-demos/core/floating-action-button.pug
@@ -13,8 +13,8 @@ block content
           a.link.fab-close Link 3
       .fab.fab-left-top.color-yellow
         a(href='#')
-          i.icon.f7-icons.if-not-md add
-          i.icon.f7-icons.if-not-md close
+          i.icon.f7-icons.if-not-md plus
+          i.icon.f7-icons.if-not-md xmark
           i.icon.material-icons.md-only add
           i.icon.material-icons.md-only close
         .fab-buttons.fab-buttons-bottom
@@ -23,8 +23,8 @@ block content
           a(href='') 3
       .fab.fab-right-top.color-pink
         a(href='#')
-          i.icon.f7-icons.if-not-md add
-          i.icon.f7-icons.if-not-md close
+          i.icon.f7-icons.if-not-md plus
+          i.icon.f7-icons.if-not-md xmark
           i.icon.material-icons.md-only add
           i.icon.material-icons.md-only close
         .fab-buttons.fab-buttons-left
@@ -33,8 +33,8 @@ block content
           a(href='') 3
       .fab.fab-center-center.color-green
         a(href='#')
-          i.icon.f7-icons.if-not-md add
-          i.icon.f7-icons.if-not-md close
+          i.icon.f7-icons.if-not-md plus
+          i.icon.f7-icons.if-not-md xmark
           i.icon.material-icons.md-only add
           i.icon.material-icons.md-only close
         .fab-buttons.fab-buttons-center
@@ -45,15 +45,15 @@ block content
 
       .fab.fab-left-bottom.fab-morph(data-morph-to=".toolbar")
         a(href='#')
-          i.icon.f7-icons.if-not-md add
-          i.icon.f7-icons.if-not-md close
+          i.icon.f7-icons.if-not-md plus
+          i.icon.f7-icons.if-not-md xmark
           i.icon.material-icons.md-only add
           i.icon.material-icons.md-only close
 
       .fab.fab-right-bottom.color-orange
         a(href='#')
-          i.icon.f7-icons.if-not-md add
-          i.icon.f7-icons.if-not-md close
+          i.icon.f7-icons.if-not-md plus
+          i.icon.f7-icons.if-not-md xmark
           i.icon.material-icons.md-only add
           i.icon.material-icons.md-only close
         .fab-buttons.fab-buttons-top
@@ -66,7 +66,7 @@ block content
 
       .fab.fab-extended.fab-center-bottom.color-red
         a(href='#')
-          i.icon.f7-icons.if-not-md add
+          i.icon.f7-icons.if-not-md plus
           i.icon.material-icons.md-only add
           .fab-text Create
 

--- a/src/pug/docs-demos/react/chips.pug
+++ b/src/pug/docs-demos/react/chips.pug
@@ -43,7 +43,7 @@ block content
                 <BlockTitle>Icon Chips</BlockTitle>
                 <Block strong>
                   <Chip text="Add Contact" mediaBgColor="blue">
-                    <Icon slot="media" ios="f7:add_round" aurora="f7:add_round" md="material:add_circle"></Icon>
+                    <Icon slot="media" ios="f7:plus_circle" aurora="f7:plus_circle" md="material:add_circle"></Icon>
                   </Chip>
                   <Chip text="London" mediaBgColor="green">
                     <Icon slot="media" ios="f7:compass" aurora="f7:compass" md="material:location_on"></Icon>

--- a/src/pug/docs-demos/react/floating-action-button.pug
+++ b/src/pug/docs-demos/react/floating-action-button.pug
@@ -24,8 +24,8 @@ block content
                 </Toolbar>
 
                 <Fab position="left-top" slot="fixed" color="yellow">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="bottom">
                     <FabButton>1</FabButton>
                     <FabButton>2</FabButton>
@@ -34,8 +34,8 @@ block content
                 </Fab>
 
                 <Fab position="right-top" slot="fixed" color="pink">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="left">
                     <FabButton>1</FabButton>
                     <FabButton>2</FabButton>
@@ -44,8 +44,8 @@ block content
                 </Fab>
 
                 <Fab position="center-center" slot="fixed" color="green">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="center">
                     <FabButton>1</FabButton>
                     <FabButton>2</FabButton>
@@ -55,13 +55,13 @@ block content
                 </Fab>
 
                 <Fab position="left-bottom" slot="fixed" morphTo=".toolbar.fab-morph-target">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                 </Fab>
 
                 <Fab position="right-bottom" slot="fixed" color="orange">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="top">
                     <FabButton label="Action 1">1</FabButton>
                     <FabButton label="Action 2">2</FabButton>
@@ -69,7 +69,7 @@ block content
                 </Fab>
 
                 <Fab position="center-bottom" slot="fixed" text="Create" color="red">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
                 </Fab>
 
                 <Block>

--- a/src/pug/docs-demos/vue/chips.pug
+++ b/src/pug/docs-demos/vue/chips.pug
@@ -28,7 +28,7 @@ block content
           <f7-block-title>Icon Chips</f7-block-title>
           <f7-block strong>
             <f7-chip text="Add Contact" media-bg-color="blue">
-              <f7-icon slot="media" ios="f7:add_round" aurora="f7:add_round" md="material:add_circle"></f7-icon>
+              <f7-icon slot="media" ios="f7:plus_circle" aurora="f7:plus_circle" md="material:add_circle"></f7-icon>
             </f7-chip>
             <f7-chip text="London" media-bg-color="green">
               <f7-icon slot="media" ios="f7:compass" aurora="f7:compass" md="material:location_on"></f7-icon>

--- a/src/pug/docs-demos/vue/floating-action-button.pug
+++ b/src/pug/docs-demos/vue/floating-action-button.pug
@@ -16,8 +16,8 @@ block content
 
           <!-- FAB Left Top (Yellow) -->
           <f7-fab position="left-top" slot="fixed" color="yellow">
-            <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-            <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+            <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+            <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
             <f7-fab-buttons position="bottom">
               <f7-fab-button>1</f7-fab-button>
               <f7-fab-button>2</f7-fab-button>
@@ -27,8 +27,8 @@ block content
 
           <!-- FAB Right Top (Pink) -->
           <f7-fab position="right-top" slot="fixed" color="pink">
-            <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-            <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+            <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+            <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
             <f7-fab-buttons position="left">
               <f7-fab-button>1</f7-fab-button>
               <f7-fab-button>2</f7-fab-button>
@@ -38,8 +38,8 @@ block content
 
           <!-- FAB Center (Green) -->
           <f7-fab position="center-center" slot="fixed" color="green">
-            <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-            <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+            <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+            <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
             <f7-fab-buttons position="center">
               <f7-fab-button>1</f7-fab-button>
               <f7-fab-button>2</f7-fab-button>
@@ -51,14 +51,14 @@ block content
           <!-- FAB Left Bottom (Blue) -->
           <!-- Will morph to Toolbar -->
           <f7-fab position="left-bottom" slot="fixed" morph-to=".toolbar.fab-morph-target">
-            <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-            <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+            <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+            <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
           </f7-fab>
 
           <!-- FAB Right Bottom (Orange) -->
           <f7-fab position="right-bottom" slot="fixed" color="orange">
-            <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-            <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+            <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+            <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
             <f7-fab-buttons position="top">
               <f7-fab-button label="Action 1">1</f7-fab-button>
               <f7-fab-button label="Action 2">2</f7-fab-button>
@@ -67,7 +67,7 @@ block content
 
           <!-- Extended FAB Center Bottom (Red) -->
           <f7-fab position="center-bottom" slot="fixed" text="Create" color="red">
-            <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
+            <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
           </f7-fab>
 
           <f7-block>

--- a/src/pug/docs/chips.pug
+++ b/src/pug/docs/chips.pug
@@ -88,7 +88,7 @@ block content
             <div class="block block-strong">
               <div class="chip">
                 <div class="chip-media bg-color-blue">
-                  <i class="icon f7-icons if-not-md">add_round</i>
+                  <i class="icon f7-icons if-not-md">plus_circle</i>
                   <i class="icon material-icons md-only">add_circle</i>
                 </div>
                 <div class="chip-label">Add Contact</div>

--- a/src/pug/docs/floating-action-button.pug
+++ b/src/pug/docs/floating-action-button.pug
@@ -28,13 +28,13 @@ block content
             <!-- Floating Action Button -->
             <div class="fab fab-right-bottom">
               <a href="#">
-                <i class="icon f7-icons">add</i>
+                <i class="icon f7-icons">plus</i>
               </a>
             </div>
             <!-- Another Floating Action Button -->
             <div class="fab fab-left-bottom">
               <a href="#">
-                <i class="icon f7-icons">add</i>
+                <i class="icon f7-icons">plus</i>
               </a>
             </div>
             <!-- Scrollable Page Content-->
@@ -71,7 +71,7 @@ block content
           <!-- Additional fab-extended class -->
           <div class="fab fab-extended fab-center-bottom">
             <a href="#">
-              <i class="icon f7-icons">add</i>
+              <i class="icon f7-icons">plus</i>
               <!-- Element with FAB text  -->
               <div class="fab-text">Create</div>
             </a>
@@ -83,9 +83,9 @@ block content
           <div class="fab fab-right-bottom">
             <a href="#">
               <!-- First icon is visible when Speed Dial actions are closed -->
-              <i class="icon f7-icons">add</i>
+              <i class="icon f7-icons">plus</i>
               <!-- Second icon is visible when Speed Dial actions are opened -->
-              <i class="icon f7-icons">close</i>
+              <i class="icon f7-icons">xmark</i>
             </a>
             <!-- Speed Dial action buttons -->
             <div class="fab-buttons fab-buttons-bottom">
@@ -139,7 +139,7 @@ block content
 
         <!-- FAB will morph to toolbar -->
         <div class="fab fab-morph" data-morph-to=".toolbar">
-          <i class="icon f7-icons">add</i>
+          <i class="icon f7-icons">plus</i>
         </div>
 
         <div class="page-content">
@@ -223,8 +223,8 @@ block content
               <div class="fab fab-left-top color-yellow">
                 <a href="#">
                   <!-- Icons For iOS Theme -->
-                  <i class="icon f7-icons if-not-md">add</i>
-                  <i class="icon f7-icons if-not-md">close</i>
+                  <i class="icon f7-icons if-not-md">plus</i>
+                  <i class="icon f7-icons if-not-md">xmark</i>
                   <!-- Icons For MD Theme -->
                   <i class="icon material-icons md-only">add</i>
                   <i class="icon material-icons md-only">close</i>
@@ -278,7 +278,7 @@ block content
               <!-- Extended FAB Center Bottom (Red) -->
               <div class="fab fab-extended fab-center-bottom color-red">
                 <a href="#">
-                  <i class="icon f7-icons if-not-md">add</i>
+                  <i class="icon f7-icons if-not-md">plus</i>
                   <i class="icon material-icons md-only">add</i>
                   <div class="fab-text">Create</div>
                 </a>

--- a/src/pug/react/chips.pug
+++ b/src/pug/react/chips.pug
@@ -114,7 +114,7 @@ block content
                     <BlockTitle>Icon Chips</BlockTitle>
                     <Block strong>
                       <Chip text="Add Contact" mediaBgColor="blue">
-                        <Icon slot="media" ios="f7:add_round" aurora="f7:add_round" md="material:add_circle"></Icon>
+                        <Icon slot="media" ios="f7:plus_circle" aurora="f7:plus_circle" md="material:add_circle"></Icon>
                       </Chip>
                       <Chip text="London" mediaBgColor="green">
                         <Icon slot="media" ios="f7:compass" aurora="f7:compass" md="material:location_on"></Icon>

--- a/src/pug/react/floating-action-button.pug
+++ b/src/pug/react/floating-action-button.pug
@@ -148,8 +148,8 @@ block content
 
                 {/* FAB Left Top (Yellow) */}
                 <Fab position="left-top" slot="fixed" color="yellow">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="bottom">
                     <FabButton>1</FabButton>
                     <FabButton>2</FabButton>
@@ -159,8 +159,8 @@ block content
 
                 {/* FAB Right Top (Pink) */}
                 <Fab position="right-top" slot="fixed" color="pink">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="left">
                     <FabButton>1</FabButton>
                     <FabButton>2</FabButton>
@@ -170,8 +170,8 @@ block content
 
                 {/* FAB Center (Green) */}
                 <Fab position="center-center" slot="fixed" color="green">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="center">
                     <FabButton>1</FabButton>
                     <FabButton>2</FabButton>
@@ -183,14 +183,14 @@ block content
                 {/* FAB Left Bottom (Blue) */}
                 {/* Will morph to Toolbar */}
                 <Fab position="left-bottom" slot="fixed" morphTo=".toolbar.fab-morph-target">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                 </Fab>
 
                 {/* FAB Right Bottom (Orange) */}
                 <Fab position="right-bottom" slot="fixed" color="orange">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
-                  <Icon ios="f7:close" aurora="f7:close" md="material:close"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
+                  <Icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></Icon>
                   <FabButtons position="top">
                     <FabButton label="Action 1">1</FabButton>
                     <FabButton label="Action 2">2</FabButton>
@@ -199,7 +199,7 @@ block content
 
                 {/* Extended FAB Center Bottom (Red) */}
                 <Fab position="center-bottom" slot="fixed" text="Create" color="red">
-                  <Icon ios="f7:add" aurora="f7:add" md="material:add"></Icon>
+                  <Icon ios="f7:plus" aurora="f7:plus" md="material:add"></Icon>
                 </Fab>
 
                 <Block>

--- a/src/pug/vue/chips.pug
+++ b/src/pug/vue/chips.pug
@@ -108,7 +108,7 @@ block content
                 <f7-block-title>Icon Chips</f7-block-title>
                 <f7-block strong>
                   <f7-chip text="Add Contact" media-bg-color="blue">
-                    <f7-icon slot="media" ios="f7:add_round" aurora="f7:add_round" md="material:add_circle"></f7-icon>
+                    <f7-icon slot="media" ios="f7:plus_circle" aurora="f7:plus_circle" md="material:add_circle"></f7-icon>
                   </f7-chip>
                   <f7-chip text="London" media-bg-color="green">
                     <f7-icon slot="media" ios="f7:compass" aurora="f7:compass" md="material:location_on"></f7-icon>

--- a/src/pug/vue/floating-action-button.pug
+++ b/src/pug/vue/floating-action-button.pug
@@ -147,8 +147,8 @@ block content
 
               <!-- FAB Left Top (Yellow) -->
               <f7-fab position="left-top" slot="fixed" color="yellow">
-                <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-                <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+                <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+                <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
                 <f7-fab-buttons position="bottom">
                   <f7-fab-button>1</f7-fab-button>
                   <f7-fab-button>2</f7-fab-button>
@@ -158,8 +158,8 @@ block content
 
               <!-- FAB Right Top (Pink) -->
               <f7-fab position="right-top" slot="fixed" color="pink">
-                <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-                <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+                <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+                <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
                 <f7-fab-buttons position="left">
                   <f7-fab-button>1</f7-fab-button>
                   <f7-fab-button>2</f7-fab-button>
@@ -169,8 +169,8 @@ block content
 
               <!-- FAB Center (Green) -->
               <f7-fab position="center-center" slot="fixed" color="green">
-                <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-                <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+                <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+                <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
                 <f7-fab-buttons position="center">
                   <f7-fab-button>1</f7-fab-button>
                   <f7-fab-button>2</f7-fab-button>
@@ -182,14 +182,14 @@ block content
               <!-- FAB Left Bottom (Blue) -->
               <!-- Will morph to Toolbar -->
               <f7-fab position="left-bottom" slot="fixed" morph-to=".toolbar.fab-morph-target">
-                <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-                <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+                <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+                <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
               </f7-fab>
 
               <!-- FAB Right Bottom (Orange) -->
               <f7-fab position="right-bottom" slot="fixed" color="orange">
-                <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
-                <f7-icon ios="f7:close" aurora="f7:close" md="material:close"></f7-icon>
+                <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
+                <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close"></f7-icon>
                 <f7-fab-buttons position="top">
                   <f7-fab-button label="Action 1">1</f7-fab-button>
                   <f7-fab-button label="Action 2">2</f7-fab-button>
@@ -198,7 +198,7 @@ block content
 
               <!-- Extended FAB Center Bottom (Red) -->
               <f7-fab position="center-bottom" slot="fixed" text="Create" color="red">
-                <f7-icon ios="f7:add" aurora="f7:add" md="material:add"></f7-icon>
+                <f7-icon ios="f7:plus" aurora="f7:plus" md="material:add"></f7-icon>
               </f7-fab>
 
               <f7-block>


### PR DESCRIPTION
Update icons add -> plus and close -> xmark for iOS and Aurora.

Fix https://github.com/framework7io/framework7/issues/3467