### PR TITLE
Isn't it navbar-large-transparent for large transparent titles?

### DIFF
--- a/src/pug/docs/navbar.pug
+++ b/src/pug/docs/navbar.pug
@@ -145,7 +145,7 @@ block content
     p To make large title transparent we need additional `navbar-transparent` class:
     :code(lang="html")
       <!-- additional "navbar-transparent" class -->
-      <div class="navbar navbar-large navbar-transparent">
+      <div class="navbar navbar-large navbar-large-transparent">
         <div class="navbar-bg"></div>
         <div class="navbar-inner">
           ...


### PR DESCRIPTION
It's actually not working when I use navbar-transparent here...