### PR TITLE
Update router-component.pug

### DIFF
--- a/src/pug/docs/router-component.pug
+++ b/src/pug/docs/router-component.pug
@@ -817,7 +817,7 @@ block content
         </div>
       </template>
       <script>
-        export default {
+        return {
           data() {
             return {
               loggedIn: false,


### PR DESCRIPTION
For Main App Component "export default" is not proper.
Should use simple "return" like for normal component
Not sure how it look for Webpack but for example below it doesn't work:
```
var app = new Framework7({
  componentUrl: './path/to/app.f7.html',
})
```

Docs are using "export default" few times:
1) Component Context -> $f7ready(callback)
2) Main App Component
Im pretty sure that this is only valid for Webpack.

![Zrzut ekranu z 2020-05-15 13-53-11](https://user-images.githubusercontent.com/14165726/82047966-01ff2700-96b4-11ea-9316-d51d61bd0973.png)
