### PR TITLE
Typo in example code

### DIFF
--- a/src/pug/docs/view.pug
+++ b/src/pug/docs/view.pug
@@ -655,7 +655,7 @@ block content
             p Then it is mandatory to pass params as well:
             :code(lang="js")
               router.navigate({
-                name: 'about',
+                name: 'post',
                 params: { userId: 1, postId: 2 },
               });
         tr


### PR DESCRIPTION
Typo in example code: "about" should be "post"
That's it :ok_hand: