### PR TITLE
Fixed typo in stepper pages and docs

### DIFF
--- a/src/pug/_mixins.pug
+++ b/src/pug/_mixins.pug
@@ -196,12 +196,12 @@ mixin vueLinkActionsProps
     td sortable-enable
     td string<br>boolean
     td
-    td CSS selector of the Sortable list to open on click
+    td CSS selector of the Sortable list to be enabled on click
   tr
     td sortable-disable
     td string<br>boolean
     td
-    td CSS selector of the Sortable list to close on click. Or boolean property to close currently opened Sortable list
+    td CSS selector of the Sortable list to be disabled on click. Or boolean property to close currently opened Sortable list
   tr
     td sortable-toggle
     td string<br>boolean
@@ -442,12 +442,12 @@ mixin reactLinkActionsProps
     td sortableEnable
     td string<br>boolean
     td
-    td CSS selector of the Sortable list to open on click
+    td CSS selector of the Sortable list to be enabled on click
   tr
     td sortableDisable
     td string<br>boolean
     td
-    td CSS selector of the Sortable list to close on click. Or boolean property to close currently opened Sortable list
+    td CSS selector of the Sortable list to be disabled on click. Or boolean property to close currently opened Sortable list
   tr
     td sortableToggle
     td string<br>boolean
@@ -688,12 +688,12 @@ mixin svelteLinkActionsProps
     td sortableEnable
     td string<br>boolean
     td
-    td CSS selector of the Sortable list to open on click
+    td CSS selector of the Sortable list to be enabled on click
   tr
     td sortableDisable
     td string<br>boolean
     td
-    td CSS selector of the Sortable list to close on click. Or boolean property to close currently opened Sortable list
+    td CSS selector of the Sortable list to be disabled on click. Or boolean property to close currently opened Sortable list
   tr
     td sortableToggle
     td string<br>boolean

--- a/src/pug/docs-demos/core/appbar.pug
+++ b/src/pug/docs-demos/core/appbar.pug
@@ -22,6 +22,9 @@ block content
           </div>
         </div>
       </div>
+  .panel.panel-left.panel-cover.panel-init
+    .block
+      p Panel left content
   .view.view-main.view-init
     .page
       .navbar

--- a/src/pug/docs-demos/core/appbar.pug
+++ b/src/pug/docs-demos/core/appbar.pug
@@ -7,10 +7,10 @@ block content
           <i class="f7-icons">bars</i>
         </a>
         <a href="#" class="button button-small display-flex margin-left-half">
-          <i class="f7-icons">reply_fill</i>
+          <i class="f7-icons">arrowshape_turn_up_left_fill</i>
         </a>
         <a href="#" class="button button-small display-flex margin-left-half">
-          <i class="f7-icons">forward_fill</i>
+          <i class="f7-icons">arrowshape_turn_up_right_fill</i>
         </a>
       </div>
       <div class="right">

--- a/src/pug/docs-demos/core/badge.pug
+++ b/src/pug/docs-demos/core/badge.pug
@@ -9,7 +9,7 @@ block content
           .title Badge
           .right
             a.link.icon-only
-              <i class="icon f7-icons if-not-md">person_fill<span class="badge color-red">5</span></i>
+              <i class="icon f7-icons if-not-md">person_circle_fill<span class="badge color-red">5</span></i>
               <i class="icon material-icons md-only">person<span class="badge color-red">5</span></i>
       .toolbar.tabbar.tabbar-labels.toolbar-bottom
         .toolbar-inner

--- a/src/pug/docs-demos/core/cards.pug
+++ b/src/pug/docs-demos/core/cards.pug
@@ -135,7 +135,7 @@ block content
                 <small style="opacity: 0.7">Build Mobile Apps</small>
               </div>
               <a href="#" class="link card-close card-opened-fade-in color-white" style="position: absolute; right: 15px; top: 15px">
-                <i class="icon f7-icons">multiply_circle_fill</i>
+                <i class="icon f7-icons">xmark_circle_fill</i>
               </a>
             </div>
             <div class="card-content-padding">
@@ -155,7 +155,7 @@ block content
                 <small style="opacity: 0.7">Build Mobile Apps</small>
               </div>
               <a href="#" class="link card-close card-opened-fade-in color-black" style="position: absolute; right: 15px; top: 15px">
-                <i class="icon f7-icons">multiply_circle_fill</i>
+                <i class="icon f7-icons">xmark_circle_fill</i>
               </a>
             </div>
             <div class="card-content-padding">

--- a/src/pug/docs-demos/core/data-table-collapsible.pug
+++ b/src/pug/docs-demos/core/data-table-collapsible.pug
@@ -23,7 +23,7 @@ block content
             table
               thead
                 tr
-                  th.label-cell Desert (100g serving)
+                  th.label-cell Dessert (100g serving)
                   th.numeric-cell Calories
                   th.numeric-cell Fat (g)
                   th.numeric-cell Carbs

--- a/src/pug/docs-demos/core/data-table-collapsible.pug
+++ b/src/pug/docs-demos/core/data-table-collapsible.pug
@@ -14,7 +14,7 @@ block content
             .data-table-title Nutrition
             .data-table-actions
               a.link.icon-only
-                i.icon.f7-icons.if-not-md sort
+                i.icon.f7-icons.if-not-md line_horizontal_3_decrease
                 i.icon.material-icons.md-only sort
               a.link.icon-only
                 i.icon.f7-icons.if-not-md more_vertical_round

--- a/src/pug/docs-demos/core/data-table-pagination-footer.pug
+++ b/src/pug/docs-demos/core/data-table-pagination-footer.pug
@@ -13,7 +13,7 @@ block content
           <table>
             <thead>
               <tr>
-                <th class="label-cell">Desert (100g serving)</th>
+                <th class="label-cell">Dessert (100g serving)</th>
                 <th class="numeric-cell">Calories</th>
                 <th class="numeric-cell">Fat (g)</th>
                 <th class="numeric-cell">Carbs</th>

--- a/src/pug/docs-demos/core/data-table-selectable.pug
+++ b/src/pug/docs-demos/core/data-table-selectable.pug
@@ -17,7 +17,7 @@ block content
                   label.checkbox
                     input(type="checkbox")
                     i.icon-checkbox
-                th.label-cell Desert (100g serving)
+                th.label-cell Dessert (100g serving)
                 th.numeric-cell Calories
                 th.numeric-cell Fat (g)
                 th.numeric-cell Carbs

--- a/src/pug/docs-demos/core/data-table-sortable.pug
+++ b/src/pug/docs-demos/core/data-table-sortable.pug
@@ -14,10 +14,10 @@ block content
             .data-table-title Nutrition
             .data-table-actions
               a.link.icon-only
-                i.icon.f7-icons.if-not-md sort
+                i.icon.f7-icons.if-not-md line_horizontal_3_decrease
                 i.icon.material-icons.md-only sort
               a.link.icon-only
-                i.icon.f7-icons.if-not-md more_vertical_round
+                i.icon.f7-icons.if-not-md ellipsis_vertical_circle
                 i.icon.material-icons.md-only more_vert
           .card-content
             table

--- a/src/pug/docs-demos/core/data-table-sortable.pug
+++ b/src/pug/docs-demos/core/data-table-sortable.pug
@@ -27,7 +27,7 @@ block content
                     label.checkbox
                       input(type="checkbox")
                       i.icon-checkbox
-                  th.label-cell.sortable-cell.sortable-active Desert (100g serving)
+                  th.label-cell.sortable-cell.sortable-active Dessert (100g serving)
                   th.numeric-cell.sortable-cell Calories
                   th.numeric-cell.sortable-cell Fat (g)
                   th.numeric-cell.sortable-cell Carbs

--- a/src/pug/docs-demos/core/data-table-title.pug
+++ b/src/pug/docs-demos/core/data-table-title.pug
@@ -28,7 +28,7 @@ block content
                     label.checkbox
                       input(type="checkbox")
                       i.icon-checkbox
-                  th.label-cell Desert (100g serving)
+                  th.label-cell Dessert (100g serving)
                   th.numeric-cell Calories
                   th.numeric-cell Fat (g)
                   th.numeric-cell Carbs
@@ -103,7 +103,7 @@ block content
                     label.checkbox
                       input(type="checkbox")
                       i.icon-checkbox
-                  th.label-cell Desert (100g serving)
+                  th.label-cell Dessert (100g serving)
                   th.numeric-cell Calories
                   th.numeric-cell Fat (g)
                   th.numeric-cell Carbs
@@ -170,7 +170,7 @@ block content
                     label.checkbox
                       input(type="checkbox")
                       i.icon-checkbox
-                  th.label-cell Desert (100g serving)
+                  th.label-cell Dessert (100g serving)
                   th.numeric-cell Calories
                   th.numeric-cell Fat (g)
                   th.numeric-cell Carbs

--- a/src/pug/docs-demos/core/data-table-title.pug
+++ b/src/pug/docs-demos/core/data-table-title.pug
@@ -15,10 +15,10 @@ block content
             .data-table-title Nutrition
             .data-table-actions
               a.link.icon-only
-                i.icon.f7-icons.if-not-md sort
+                i.icon.f7-icons.if-not-md line_horizontal_3_decrease
                 i.icon.material-icons.md-only sort
               a.link.icon-only
-                i.icon.f7-icons.if-not-md more_vertical_round
+                i.icon.f7-icons.if-not-md ellipsis_vertical_circle
                 i.icon.material-icons.md-only more_vert
           .card-content
             table
@@ -81,10 +81,10 @@ block content
               .data-table-title Nutrition
               .data-table-actions
                 a.link.icon-only
-                  i.icon.f7-icons.if-not-md sort
+                  i.icon.f7-icons.if-not-md line_horizontal_3_decrease
                   i.icon.material-icons.md-only sort
                 a.link.icon-only
-                  i.icon.f7-icons.if-not-md more_vertical_round
+                  i.icon.f7-icons.if-not-md ellipsis_vertical_circle
                   i.icon.material-icons.md-only more_vert
             .data-table-header-selected
               .data-table-title-selected <span class="data-table-selected-count"></span> items selected
@@ -93,7 +93,7 @@ block content
                   i.icon.f7-icons.if-not-md trash
                   i.icon.material-icons.md-only delete
                 a.link.icon-only
-                  i.icon.f7-icons.if-not-md more_vertical_round
+                  i.icon.f7-icons.if-not-md ellipsis_vertical_circle
                   i.icon.material-icons.md-only more_vert
           .card-content
             table
@@ -157,10 +157,10 @@ block content
               a.link Remove
             .data-table-actions
               a.link.icon-only
-                i.icon.f7-icons.if-not-md sort
+                i.icon.f7-icons.if-not-md line_horizontal_3_decrease
                 i.icon.material-icons.md-only sort
               a.link.icon-only
-                i.icon.f7-icons.if-not-md more_vertical_round
+                i.icon.f7-icons.if-not-md ellipsis_vertical_circle
                 i.icon.material-icons.md-only more_vert
           .card-content
             table

--- a/src/pug/docs-demos/core/data-table-title.pug
+++ b/src/pug/docs-demos/core/data-table-title.pug
@@ -189,7 +189,7 @@ block content
                   td.numeric-cell 4.0
                   td.actions-cell
                     a.link.icon-only
-                      i.icon.f7-icons.if-not-md compose
+                      i.icon.f7-icons.if-not-md square_pencil
                       i.icon.material-icons.md-only edit
                     a.link.icon-only
                       i.icon.f7-icons.if-not-md trash
@@ -206,7 +206,7 @@ block content
                   td.numeric-cell 4.4
                   td.actions-cell
                     a.link.icon-only
-                      i.icon.f7-icons.if-not-md compose
+                      i.icon.f7-icons.if-not-md square_pencil
                       i.icon.material-icons.md-only edit
                     a.link.icon-only
                       i.icon.f7-icons.if-not-md trash
@@ -223,7 +223,7 @@ block content
                   td.numeric-cell 6.0
                   td.actions-cell
                     a.link.icon-only
-                      i.icon.f7-icons.if-not-md compose
+                      i.icon.f7-icons.if-not-md square_pencil
                       i.icon.material-icons.md-only edit
                     a.link.icon-only
                       i.icon.f7-icons.if-not-md trash
@@ -240,7 +240,7 @@ block content
                   td.numeric-cell 4.3
                   td.actions-cell
                     a.link.icon-only
-                      i.icon.f7-icons.if-not-md compose
+                      i.icon.f7-icons.if-not-md square_pencil
                       i.icon.material-icons.md-only edit
                     a.link.icon-only
                       i.icon.f7-icons.if-not-md trash

--- a/src/pug/docs-demos/core/data-table.pug
+++ b/src/pug/docs-demos/core/data-table.pug
@@ -14,7 +14,7 @@ block content
           table
             thead
               tr
-                th.label-cell Desert (100g serving)
+                th.label-cell Dessert (100g serving)
                 th.numeric-cell Calories
                 th.numeric-cell Fat (g)
                 th.numeric-cell Carbs
@@ -54,7 +54,7 @@ block content
           table
             thead
               tr
-                th.label-cell Desert (100g serving)
+                th.label-cell Dessert (100g serving)
                 th.numeric-cell Calories
                 th.numeric-cell Fat (g)
                 th.numeric-cell Carbs

--- a/src/pug/docs-demos/core/messages.pug
+++ b/src/pug/docs-demos/core/messages.pug
@@ -127,7 +127,7 @@ block scripts
       tailMessageRule: function (message, previousMessage, nextMessage) {
         // Skip if title
         if (message.isTitle) return false;
-          /* if (bascially same as lastMessageRule):
+          /* if (basically same as lastMessageRule):
           - there is no next message
           - or next message type (send/received) is different
           - or next message sender name is different

--- a/src/pug/docs-demos/core/range-slider.pug
+++ b/src/pug/docs-demos/core/range-slider.pug
@@ -43,7 +43,7 @@ block content
                 </div>
               </div>
               <div class="item-cell width-auto flex-shrink-0">
-                <i class="icon f7-icons if-not-md" style="width:25px">sun_max</i>
+                <i class="icon f7-icons if-not-md" style="width:25px">sun_max_fill</i>
                 <i class="icon material-icons md-only" style="width:24px">brightness_high</i>
               </div>
             </li>
@@ -54,14 +54,14 @@ block content
           <ul>
             <li class="item-row">
               <div class="item-cell width-auto flex-shrink-0">
-                <i class="icon f7-icons if-not-md" style="width:25px">money_dollar_round</i>
+                <i class="icon f7-icons if-not-md" style="width:25px">money_dollar_circle</i>
                 <i class="icon material-icons md-only" style="width:24px">attach_money</i>
               </div>
               <div class="item-cell item-cell-shrink-3">
                 <div id="price-filter" class="range-slider range-slider-init color-green" data-label="true" data-dual="true" data-min="0" data-max="500" data-step="1" data-value-left="200" data-value-right="400"></div>
               </div>
               <div class="item-cell width-auto flex-shrink-0">
-                <i class="icon f7-icons if-not-md" style="width:25px">money_dollar_round_fill</i>
+                <i class="icon f7-icons if-not-md" style="width:25px">money_dollar_circle_fill</i>
                 <i class="icon material-icons md-only" style="width:24px">monetization_on</i>
               </div>
             </li>

--- a/src/pug/docs-demos/core/stepper.pug
+++ b/src/pug/docs-demos/core/stepper.pug
@@ -504,7 +504,7 @@ block content
           </ul>
         </div>
         <div class="block-title">Manual input</div>
-        <div class="block-header">It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</div>
+        <div class="block-header">It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</div>
         <div class="block block-strong text-align-center">
           <div class="row">
             <div class="col">

--- a/src/pug/docs-demos/core/toolbar-tabbar.pug
+++ b/src/pug/docs-demos/core/toolbar-tabbar.pug
@@ -198,7 +198,7 @@ block scripts
           <div class="right">
             <a class="link toggle-toolbar-position">
               <i class="md-only icon material-icons rotate-icon">compare_arrows</i>
-              <i class="if-not-md icon f7-icons">reload</i>
+              <i class="if-not-md icon f7-icons">arrow_up_arrow_down_circle_fill</i>
             </a>
           </div>
       .toolbar.tabbar-labels.toolbar-bottom

--- a/src/pug/docs-demos/core/treeview.pug
+++ b/src/pug/docs-demos/core/treeview.pug
@@ -188,7 +188,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">cv.docx</div>
                               </div>
                             </div>
@@ -196,7 +196,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">info.docx</div>
                               </div>
                             </div>
@@ -214,7 +214,7 @@ block scripts
                       <div class="treeview-item">
                         <div class="treeview-item-root">
                           <div class="treeview-item-content">
-                            <i class="icon f7-icons">document_text_fill</i>
+                            <i class="icon f7-icons">doc_text_fill</i>
                             <div class="treeview-item-label">index.html</div>
                           </div>
                         </div>
@@ -284,7 +284,7 @@ block scripts
                                   <input type="checkbox">
                                   <i class="icon-checkbox"></i>
                                 </label>
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">cv.docx</div>
                               </div>
                             </div>
@@ -296,7 +296,7 @@ block scripts
                                   <input type="checkbox">
                                   <i class="icon-checkbox"></i>
                                 </label>
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">info.docx</div>
                               </div>
                             </div>
@@ -322,7 +322,7 @@ block scripts
                               <input type="checkbox">
                               <i class="icon-checkbox"></i>
                             </label>
-                            <i class="icon f7-icons">document_text_fill</i>
+                            <i class="icon f7-icons">doc_text_fill</i>
                             <div class="treeview-item-label">index.html</div>
                           </div>
                         </div>
@@ -372,7 +372,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">cv.docx</div>
                               </div>
                             </div>
@@ -380,7 +380,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">info.docx</div>
                               </div>
                             </div>
@@ -398,7 +398,7 @@ block scripts
                       <div class="treeview-item">
                         <div class="treeview-item-root">
                           <div class="treeview-item-content">
-                            <i class="icon f7-icons">document_text_fill</i>
+                            <i class="icon f7-icons">doc_text_fill</i>
                             <div class="treeview-item-label">index.html</div>
                           </div>
                         </div>
@@ -448,7 +448,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root treeview-item-selectable" @click="toggleSelectable">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">cv.docx</div>
                               </div>
                             </div>
@@ -456,7 +456,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root treeview-item-selectable" @click="toggleSelectable">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">document_text_fill</i>
+                                <i class="icon f7-icons">doc_text_fill</i>
                                 <div class="treeview-item-label">info.docx</div>
                               </div>
                             </div>
@@ -474,7 +474,7 @@ block scripts
                       <div class="treeview-item">
                         <div class="treeview-item-root treeview-item-selectable" @click="toggleSelectable">
                           <div class="treeview-item-content">
-                            <i class="icon f7-icons">document_text_fill</i>
+                            <i class="icon f7-icons">doc_text_fill</i>
                             <div class="treeview-item-label">index.html</div>
                           </div>
                         </div>
@@ -489,7 +489,7 @@ block scripts
                         <div class="treeview-item-root">
                           <div class="treeview-toggle"></div>
                           <div class="treeview-item-content">
-                            <i class="icon f7-icons">persons</i>
+                            <i class="icon f7-icons">person_2_fill</i>
                             <div class="treeview-item-label">Users</div>
                           </div>
                         </div>
@@ -498,7 +498,7 @@ block scripts
                           <div class="treeview-item">
                             <div class="treeview-item-root">
                               <div class="treeview-item-content">
-                                <i class="icon f7-icons">person</i>
+                                <i class="icon f7-icons">person_fill</i>
                                 <div class="treeview-item-label">{{name}}</div>
                               </div>
                             </div>
@@ -517,7 +517,7 @@ block scripts
                         <div class="treeview-item-root treeview-item-toggle">
                           <div class="treeview-toggle"></div>
                           <div class="treeview-item-content">
-                            <i class="icon f7-icons">data_fill</i>
+                            <i class="icon f7-icons">square_grid_2x2_fill</i>
                             <div class="treeview-item-label">Modals</div>
                           </div>
                         </div>
@@ -552,7 +552,7 @@ block scripts
                         <div class="treeview-item-root treeview-item-toggle">
                           <div class="treeview-toggle"></div>
                           <div class="treeview-item-content">
-                            <i class="icon f7-icons">data_fill</i>
+                            <i class="icon f7-icons">square_grid_2x2_fill</i>
                             <div class="treeview-item-label">Navigation Bars</div>
                           </div>
                         </div>

--- a/src/pug/docs-demos/react/badge.pug
+++ b/src/pug/docs-demos/react/badge.pug
@@ -18,7 +18,7 @@ block content
                 <Navbar sliding title="Badge">
                   <NavRight>
                     <Link iconOnly>
-                      <Icon ios="f7:person_fill" aurora="f7:person_fill" md="material:person">
+                      <Icon ios="f7:person_circle_fill" aurora="f7:person_circle_fill" md="material:person">
                         <Badge color="red">5</Badge>
                       </Icon>
                     </Link>

--- a/src/pug/docs-demos/react/cards.pug
+++ b/src/pug/docs-demos/react/cards.pug
@@ -160,7 +160,7 @@ block content
                         <br />
                         <small style={{opacity: 0.7}}>Build Mobile Apps</small>
                       </CardHeader>
-                      <Link cardClose color="white" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="multiply_circle_fill" />
+                      <Link cardClose color="white" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="xmark_circle_fill" />
                     </div>
                     <div className="card-content-padding">
                       <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel. It is also an indispensable prototyping apps tool to show working app prototype as soon as possible in case you need to. Framework7 is created by Vladimir Kharlampidi (iDangero.us).</p>
@@ -179,7 +179,7 @@ block content
                         <br/>
                         <small style={{opacity: 0.7}}>Build Mobile Apps</small>
                       </CardHeader>
-                      <Link cardClose color="black" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="multiply_circle_fill" />
+                      <Link cardClose color="black" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="xmark_circle_fill" />
                     </div>
                     <div className="card-content-padding">
                       <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel. It is also an indispensable prototyping apps tool to show working app prototype as soon as possible in case you need to. Framework7 is created by Vladimir Kharlampidi (iDangero.us).</p>

--- a/src/pug/docs-demos/react/range-slider.pug
+++ b/src/pug/docs-demos/react/range-slider.pug
@@ -68,7 +68,7 @@ block content
                       ></Range>
                     </ListItemCell>
                     <ListItemCell className="width-auto flex-shrink-0">
-                      <Icon ios="f7:sun_max" aurora="f7:sun_max" md="material:brightness_high"></Icon>
+                      <Icon ios="f7:sun_max_fill" aurora="f7:sun_max_fill" md="material:brightness_high"></Icon>
                     </ListItemCell>
                   </ListItem>
                 </List>
@@ -77,7 +77,7 @@ block content
                 <List simpleList>
                   <ListItem>
                     <ListItemCell className="width-auto flex-shrink-0">
-                      <Icon ios="f7:money_dollar_round" aurora="f7:money_dollar_round" md="material:attach_money"></Icon>
+                      <Icon ios="f7:money_dollar_circle" aurora="f7:money_dollar_circle" md="material:attach_money"></Icon>
                     </ListItemCell>
                     <ListItemCell className="flex-shrink-3">
                       <Range
@@ -92,7 +92,7 @@ block content
                       ></Range>
                     </ListItemCell>
                     <ListItemCell className="width-auto flex-shrink-0">
-                      <Icon ios="f7:money_dollar_round_fill" aurora="f7:money_dollar_round_fill" md="material:monetization_on"></Icon>
+                      <Icon ios="f7:money_dollar_circle_fill" aurora="f7:money_dollar_circle_fill" md="material:monetization_on"></Icon>
                     </ListItemCell>
                   </ListItem>
                 </List>

--- a/src/pug/docs-demos/react/stepper.pug
+++ b/src/pug/docs-demos/react/stepper.pug
@@ -292,7 +292,7 @@ block content
                 </List>
 
                 <BlockTitle>Manual input</BlockTitle>
-                <BlockHeader>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</BlockHeader>
+                <BlockHeader>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</BlockHeader>
                 <Block strong className="text-align-center">
                   <Row>
                     <Col>

--- a/src/pug/docs-demos/react/treeview.pug
+++ b/src/pug/docs-demos/react/treeview.pug
@@ -92,11 +92,11 @@ block content
                       <TreeviewItem label="background.jpg" iconF7="photo_fill" />
                     </TreeviewItem>
                     <TreeviewItem label="documents" iconF7="folder_fill">
-                      <TreeviewItem label="cv.docx" iconF7="document_text_fill" />
-                      <TreeviewItem label="info.docx" iconF7="document_text_fill" />
+                      <TreeviewItem label="cv.docx" iconF7="doc_text_fill" />
+                      <TreeviewItem label="info.docx" iconF7="doc_text_fill" />
                     </TreeviewItem>
                     <TreeviewItem label=".gitignore" iconF7="logo_github" />
-                    <TreeviewItem label="index.html" iconF7="document_text_fill" />
+                    <TreeviewItem label="index.html" iconF7="doc_text_fill" />
                   </Treeview>
                 </Block>
 
@@ -140,7 +140,7 @@ block content
                           this.setState({...this.state});
                         }}
                       />
-                      <TreeviewItem label="cv.docx" iconF7="document_text_fill">
+                      <TreeviewItem label="cv.docx" iconF7="doc_text_fill">
                         <Checkbox slot="content-start"
                           checked={this.state.checkboxes.documents['cv.docx']}
                           onChange={(e) => {
@@ -149,7 +149,7 @@ block content
                           }}
                         />
                       </TreeviewItem>
-                      <TreeviewItem label="info.docx" iconF7="document_text_fill">
+                      <TreeviewItem label="info.docx" iconF7="doc_text_fill">
                         <Checkbox slot="content-start"
                           checked={this.state.checkboxes.documents['info.docx']}
                           onChange={(e) => {
@@ -165,7 +165,7 @@ block content
                         this.setState({...this.state});
                       }}/>
                     </TreeviewItem>
-                    <TreeviewItem label="index.html" iconF7="document_text_fill">
+                    <TreeviewItem label="index.html" iconF7="doc_text_fill">
                       <Checkbox slot="content-start" checked={this.state.checkboxes['index.html']} onChange={(e) => {
                         this.state.checkboxes['index.html'] = e.target.checked;
                         this.setState({...this.state});
@@ -182,11 +182,11 @@ block content
                       <TreeviewItem label="background.jpg" iconF7="photo_fill" />
                     </TreeviewItem>
                     <TreeviewItem itemToggle label="documents" iconF7="folder_fill">
-                      <TreeviewItem label="cv.docx" iconF7="document_text_fill" />
-                      <TreeviewItem label="info.docx" iconF7="document_text_fill" />
+                      <TreeviewItem label="cv.docx" iconF7="doc_text_fill" />
+                      <TreeviewItem label="info.docx" iconF7="doc_text_fill" />
                     </TreeviewItem>
                     <TreeviewItem label=".gitignore" iconF7="logo_github" />
-                    <TreeviewItem label="index.html" iconF7="document_text_fill" />
+                    <TreeviewItem label="index.html" iconF7="doc_text_fill" />
                   </Treeview>
                 </Block>
 
@@ -226,14 +226,14 @@ block content
                         selectable
                         selected={this.state.selectedItem === 'cv.docx'}
                         label="cv.docx"
-                        iconF7="document_text_fill"
+                        iconF7="doc_text_fill"
                         onClick={(e) => this.toggleSelectable(e, 'cv.docx')}
                       />
                       <TreeviewItem
                         selectable
                         selected={this.state.selectedItem === 'info.docx'}
                         label="info.docx"
-                        iconF7="document_text_fill"
+                        iconF7="doc_text_fill"
                         onClick={(e) => this.toggleSelectable(e, 'info.docx')}
                       />
                     </TreeviewItem>
@@ -248,7 +248,7 @@ block content
                       selectable
                       selected={this.state.selectedItem === 'index.html'}
                       label="index.html"
-                      iconF7="document_text_fill"
+                      iconF7="doc_text_fill"
                       onClick={(e) => this.toggleSelectable(e, 'index.html')}
                     />
                   </Treeview>
@@ -260,14 +260,14 @@ block content
                     <TreeviewItem
                       toggle
                       loadChildren
-                      iconF7="persons"
+                      iconF7="person_2_fill"
                       label="Users"
                       onTreeviewLoadChildren={(e, done) => this.loadChildren(done)}
                     >
                       {this.state.loadedChildren.map((item, index) => (
                         <TreeviewItem
                           key={index}
-                          iconF7="person"
+                          iconF7="person_fill"
                           label={item.name}
                         />
                       ))}
@@ -278,12 +278,12 @@ block content
                 <BlockTitle>With links</BlockTitle>
                 <Block strong className="no-padding-horizontal">
                   <Treeview>
-                    <TreeviewItem iconF7="data_fill" itemToggle label="Modals">
+                    <TreeviewItem iconF7="square_grid_2x2_fill" itemToggle label="Modals">
                       <TreeviewItem link="/popup/" iconF7="link" label="Popup" />
                       <TreeviewItem link="/dialog/" iconF7="link" label="Dialog" />
                       <TreeviewItem link="/action-sheet/" iconF7="link" label="Action Sheet" />
                     </TreeviewItem>
-                    <TreeviewItem iconF7="data_fill" itemToggle label="Navigation Bars">
+                    <TreeviewItem iconF7="square_grid_2x2_fill" itemToggle label="Navigation Bars">
                       <TreeviewItem link="/navbar/" iconF7="link" label="Navbar" />
                       <TreeviewItem link="/toolbar-tabbar/" iconF7="link" label="Toolbar & Tabbar" />
                     </TreeviewItem>

--- a/src/pug/docs-demos/svelte/badge.svelte
+++ b/src/pug/docs-demos/svelte/badge.svelte
@@ -5,7 +5,7 @@
       <Navbar sliding title="Badge">
         <NavRight>
           <Link iconOnly>
-            <Icon ios="f7:person_fill" aurora="f7:person_fill" md="material:person">
+            <Icon ios="f7:person_circle_fill" aurora="f7:person_circle_fill" md="material:person">
               <Badge color="red">5</Badge>
             </Icon>
           </Link>

--- a/src/pug/docs-demos/svelte/cards.svelte
+++ b/src/pug/docs-demos/svelte/cards.svelte
@@ -147,7 +147,7 @@
               <br />
               <small style="opacity: 0.7">Build Mobile Apps</small>
             </CardHeader>
-            <Link cardClose color="white" class="card-opened-fade-in" style="position: absolute; right: 15px; top: 15px" iconF7="multiply_circle_fill" />
+            <Link cardClose color="white" class="card-opened-fade-in" style="position: absolute; right: 15px; top: 15px" iconF7="xmark_circle_fill" />
           </div>
           <div class="card-content-padding">
             <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel. It is also an indispensable prototyping apps tool to show working app prototype as soon as possible in case you need to. Framework7 is created by Vladimir Kharlampidi (iDangero.us).</p>
@@ -166,7 +166,7 @@
               <br/>
               <small style="opacity: 0.7">Build Mobile Apps</small>
             </CardHeader>
-            <Link cardClose color="black" class="card-opened-fade-in" style="position: absolute; right: 15px; top: 15px" iconF7="multiply_circle_fill" />
+            <Link cardClose color="black" class="card-opened-fade-in" style="position: absolute; right: 15px; top: 15px" iconF7="xmark_circle_fill" />
           </div>
           <div class="card-content-padding">
             <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel. It is also an indispensable prototyping apps tool to show working app prototype as soon as possible in case you need to. Framework7 is created by Vladimir Kharlampidi (iDangero.us).</p>

--- a/src/pug/docs-demos/svelte/range-slider.svelte
+++ b/src/pug/docs-demos/svelte/range-slider.svelte
@@ -40,7 +40,7 @@
             ></Range>
           </ListItemCell>
           <ListItemCell class="width-auto flex-shrink-0">
-            <Icon ios="f7:sun_max" aurora="f7:sun_max" md="material:brightness_high"></Icon>
+            <Icon ios="f7:sun_max_fill" aurora="f7:sun_max_fill" md="material:brightness_high"></Icon>
           </ListItemCell>
         </ListItem>
       </List>
@@ -52,7 +52,7 @@
       <List simpleList>
         <ListItem>
           <ListItemCell class="width-auto flex-shrink-0">
-            <Icon ios="f7:money_dollar_round" aurora="f7:money_dollar_round" md="material:attach_money"></Icon>
+            <Icon ios="f7:money_dollar_circle" aurora="f7:money_dollar_circle" md="material:attach_money"></Icon>
           </ListItemCell>
           <ListItemCell class="flex-shrink-3">
             <Range
@@ -67,7 +67,7 @@
             ></Range>
           </ListItemCell>
           <ListItemCell class="width-auto flex-shrink-0">
-            <Icon ios="f7:money_dollar_round_fill" aurora="f7:money_dollar_round_fill" md="material:monetization_on"></Icon>
+            <Icon ios="f7:money_dollar_circle_fill" aurora="f7:money_dollar_circle_fill" md="material:monetization_on"></Icon>
           </ListItemCell>
         </ListItem>
       </List>

--- a/src/pug/docs-demos/vue/badge.pug
+++ b/src/pug/docs-demos/vue/badge.pug
@@ -8,7 +8,7 @@ block content
           <f7-navbar sliding title="Badge">
             <f7-nav-right>
               <f7-link icon-only>
-                <f7-icon ios="f7:person_fill" aurora="f7:person_fill" md="material:person">
+                <f7-icon ios="f7:person_circle_fill" aurora="f7:person_circle_fill" md="material:person">
                   <f7-badge color="red">5</f7-badge>
                 </f7-icon>
               </f7-link>

--- a/src/pug/docs-demos/vue/cards.pug
+++ b/src/pug/docs-demos/vue/cards.pug
@@ -150,7 +150,7 @@ block content
                   <br />
                   <small :style="{opacity: 0.7}">Build Mobile Apps</small>
                 </f7-card-header>
-                <f7-link card-close color="white" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="multiply_circle_fill"></f7-link>
+                <f7-link card-close color="white" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="xmark_circle_fill"></f7-link>
               </div>
               <div class="card-content-padding">
                 <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel. It is also an indispensable prototyping apps tool to show working app prototype as soon as possible in case you need to. Framework7 is created by Vladimir Kharlampidi (iDangero.us).</p>
@@ -169,7 +169,7 @@ block content
                   <br/>
                   <small :style="{opacity: 0.7}">Build Mobile Apps</small>
                 </f7-card-header>
-                <f7-link card-close color="black" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="multiply_circle_fill"></f7-link>
+                <f7-link card-close color="black" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="xmark_circle_fill"></f7-link>
               </div>
               <div class="card-content-padding">
                 <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel. It is also an indispensable prototyping apps tool to show working app prototype as soon as possible in case you need to. Framework7 is created by Vladimir Kharlampidi (iDangero.us).</p>

--- a/src/pug/docs-demos/vue/range-slider.pug
+++ b/src/pug/docs-demos/vue/range-slider.pug
@@ -30,7 +30,7 @@ block content
                 <f7-range :min="0" :max="100" :step="1" :value="50" :label="true" color="orange"></f7-range>
               </f7-list-item-cell>
               <f7-list-item-cell class="flex-shrink-0" :style="{width: $theme.ios ? '28px' : ($theme.md ? '24px' : '18px')}">
-                <f7-icon ios="f7:sun_max" aurora="f7:sun_max" md="material:brightness_high"></f7-icon>
+                <f7-icon ios="f7:sun_max_fill" aurora="f7:sun_max_fill" md="material:brightness_high"></f7-icon>
               </f7-list-item-cell>
             </f7-list-item>
           </f7-list>
@@ -39,13 +39,13 @@ block content
           <f7-list simple-list>
             <f7-list-item>
               <f7-list-item-cell class="flex-shrink-0" :style="{width: $theme.ios ? '28px' : ($theme.md ? '24px' : '18px')}">
-                <f7-icon ios="f7:money_dollar_round" aurora="f7:money_dollar_round" md="material:attach_money"></f7-icon>
+                <f7-icon ios="f7:money_dollar_circle" aurora="f7:money_dollar_circle" md="material:attach_money"></f7-icon>
               </f7-list-item-cell>
               <f7-list-item-cell class="flex-shrink-3">
                 <f7-range :min="0" :max="500" :step="1" :value="[priceMin, priceMax]" :label="true" :dual="true" color="green" @range:change="onPriceChange"></f7-range>
               </f7-list-item-cell>
               <f7-list-item-cell class="flex-shrink-0" :style="{width: $theme.ios ? '28px' : ($theme.md ? '24px' : '18px')}">
-                <f7-icon ios="f7:money_dollar_round_fill" aurora="f7:money_dollar_round_fill" md="material:monetization_on"></f7-icon>
+                <f7-icon ios="f7:money_dollar_circle_fill" aurora="f7:money_dollar_circle_fill" md="material:monetization_on"></f7-icon>
               </f7-list-item-cell>
             </f7-list-item>
           </f7-list>

--- a/src/pug/docs-demos/vue/stepper.pug
+++ b/src/pug/docs-demos/vue/stepper.pug
@@ -256,7 +256,7 @@ block content
           </f7-list>
 
           <f7-block-title>Manual input</f7-block-title>
-          <f7-block-header>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</f7-block-header>
+          <f7-block-header>It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.</f7-block-header>
           <f7-block strong class="text-align-center">
             <f7-row>
               <f7-col>

--- a/src/pug/docs-demos/vue/treeview.pug
+++ b/src/pug/docs-demos/vue/treeview.pug
@@ -42,11 +42,11 @@ block content
                 <f7-treeview-item label="background.jpg" icon-f7="photo_fill"></f7-treeview-item>
               </f7-treeview-item>
               <f7-treeview-item label="documents" icon-f7="folder_fill">
-                <f7-treeview-item label="cv.docx" icon-f7="document_text_fill"></f7-treeview-item>
-                <f7-treeview-item label="info.docx" icon-f7="document_text_fill"></f7-treeview-item>
+                <f7-treeview-item label="cv.docx" icon-f7="doc_text_fill"></f7-treeview-item>
+                <f7-treeview-item label="info.docx" icon-f7="doc_text_fill"></f7-treeview-item>
               </f7-treeview-item>
               <f7-treeview-item label=".gitignore" icon-f7="logo_github"></f7-treeview-item>
-              <f7-treeview-item label="index.html" icon-f7="document_text_fill"></f7-treeview-item>
+              <f7-treeview-item label="index.html" icon-f7="doc_text_fill"></f7-treeview-item>
             </f7-treeview>
           </f7-block>
 
@@ -78,13 +78,13 @@ block content
                   :indeterminate="Object.values(checkboxes.documents).indexOf(false) >= 0 && Object.values(checkboxes.documents).indexOf(true) >= 0"
                   @change="(e) => Object.keys(checkboxes.documents).forEach(k => checkboxes.documents[k] = e.target.checked)"
                 ></f7-checkbox>
-                <f7-treeview-item label="cv.docx" icon-f7="document_text_fill">
+                <f7-treeview-item label="cv.docx" icon-f7="doc_text_fill">
                   <f7-checkbox slot="content-start"
                     :checked="checkboxes.documents['cv.docx']"
                     @change="checkboxes.documents['cv.docx'] = $event.target.checked"
                   ></f7-checkbox>
                 </f7-treeview-item>
-                <f7-treeview-item label="info.docx" icon-f7="document_text_fill">
+                <f7-treeview-item label="info.docx" icon-f7="doc_text_fill">
                   <f7-checkbox slot="content-start"
                     :checked="checkboxes.documents['info.docx']"
                     @change="checkboxes.documents['info.docx'] = $event.target.checked"
@@ -97,7 +97,7 @@ block content
                   @change="checkboxes['.gitignore'] = $event.target.checked"
                 ></f7-checkbox>
               </f7-treeview-item>
-              <f7-treeview-item label="index.html" icon-f7="document_text_fill">
+              <f7-treeview-item label="index.html" icon-f7="doc_text_fill">
                 <f7-checkbox slot="content-start"
                   :checked="checkboxes['index.html']"
                   @change="checkboxes['index.html'] = $event.target.checked"
@@ -114,11 +114,11 @@ block content
                 <f7-treeview-item label="background.jpg" icon-f7="photo_fill"></f7-treeview-item>
               </f7-treeview-item>
               <f7-treeview-item item-toggle label="documents" icon-f7="folder_fill">
-                <f7-treeview-item label="cv.docx" icon-f7="document_text_fill"></f7-treeview-item>
-                <f7-treeview-item label="info.docx" icon-f7="document_text_fill"></f7-treeview-item>
+                <f7-treeview-item label="cv.docx" icon-f7="doc_text_fill"></f7-treeview-item>
+                <f7-treeview-item label="info.docx" icon-f7="doc_text_fill"></f7-treeview-item>
               </f7-treeview-item>
               <f7-treeview-item label=".gitignore" icon-f7="logo_github"></f7-treeview-item>
-              <f7-treeview-item label="index.html" icon-f7="document_text_fill"></f7-treeview-item>
+              <f7-treeview-item label="index.html" icon-f7="doc_text_fill"></f7-treeview-item>
             </f7-treeview>
           </f7-block>
 
@@ -158,14 +158,14 @@ block content
                   selectable
                   :selected="selectedItem === 'cv.docx'"
                   label="cv.docx"
-                  icon-f7="document_text_fill"
+                  icon-f7="doc_text_fill"
                   @click="toggleSelectable($event, 'cv.docx')"
                 ></f7-treeview-item>
                 <f7-treeview-item
                   selectable
                   :selected="selectedItem === 'info.docx'"
                   label="info.docx"
-                  icon-f7="document_text_fill"
+                  icon-f7="doc_text_fill"
                   @click="toggleSelectable($event, 'info.docx')"
                 ></f7-treeview-item>
               </f7-treeview-item>
@@ -180,7 +180,7 @@ block content
                 selectable
                 :selected="selectedItem === 'index.html'"
                 label="index.html"
-                icon-f7="document_text_fill"
+                icon-f7="doc_text_fill"
                 @click="toggleSelectable($event, 'index.html')"
               ></f7-treeview-item>
             </f7-treeview>
@@ -192,14 +192,14 @@ block content
               <f7-treeview-item
                 toggle
                 load-children
-                icon-f7="persons"
+                icon-f7="person_2_fill"
                 label="Users"
                 @treeview:loadchildren="loadChildren"
               >
                 <f7-treeview-item
                   v-for="(item, index) in loadedChildren"
                   :key="index"
-                  icon-f7="person"
+                  icon-f7="person_fill"
                   :label="item.name"
                 ></f7-treeview-item>
               </f7-treeview-item>
@@ -209,12 +209,12 @@ block content
           <f7-block-title>With links</f7-block-title>
           <f7-block strong class="no-padding-horizontal">
             <f7-treeview>
-              <f7-treeview-item icon-f7="data_fill" item-toggle label="Modals">
+              <f7-treeview-item icon-f7="square_grid_2x2_fill" item-toggle label="Modals">
                 <f7-treeview-item link="/popup/" icon-f7="link" label="Popup" ></f7-treeview-item>
                 <f7-treeview-item link="/dialog/" icon-f7="link" label="Dialog" ></f7-treeview-item>
                 <f7-treeview-item link="/action-sheet/" icon-f7="link" label="Action Sheet" ></f7-treeview-item>
               </f7-treeview-item>
-              <f7-treeview-item icon-f7="data_fill" item-toggle label="Navigation Bars">
+              <f7-treeview-item icon-f7="square_grid_2x2_fill" item-toggle label="Navigation Bars">
                 <f7-treeview-item link="/navbar/" icon-f7="link" label="Navbar" ></f7-treeview-item>
                 <f7-treeview-item link="/toolbar-tabbar/" icon-f7="link" label="Toolbar & Tabbar" ></f7-treeview-item>
               </f7-treeview-item>

--- a/src/pug/docs/appbar.pug
+++ b/src/pug/docs/appbar.pug
@@ -57,10 +57,10 @@ block content
                   <i class="f7-icons">bars</i>
                 </a>
                 <a href="#" class="button button-small display-flex margin-left-half">
-                  <i class="f7-icons">reply_fill</i>
+                  <i class="f7-icons">arrowshape_turn_up_left_fill</i>
                 </a>
                 <a href="#" class="button button-small display-flex margin-left-half">
-                  <i class="f7-icons">forward_fill</i>
+                  <i class="f7-icons">arrowshape_turn_up_right_fill</i>
                 </a>
               </div>
               <div class="right">

--- a/src/pug/docs/appbar.pug
+++ b/src/pug/docs/appbar.pug
@@ -40,8 +40,6 @@ block content
         ...
 
       </div>
-    :code(lang="html")
-          <span class="badge">32</span>
 
     +cssVars('appbar')
 
@@ -81,7 +79,7 @@ block content
               <div class="navbar">
                 <div class="navbar-bg"></div>
                 <div class="navbar-inner">
-                  <div class="title">Badge</div>
+                  <div class="title">Appbar</div>
                 </div>
               </div>
               <div class="page-content">

--- a/src/pug/docs/badge.pug
+++ b/src/pug/docs/badge.pug
@@ -39,7 +39,7 @@ block content
               <div class="title">Badge</div>
               <div class="right">
                 <a class="link icon-only">
-                  <i class="icon f7-icons if-not-md">person_fill<span class="badge color-red">5</span></i>
+                  <i class="icon f7-icons if-not-md">person_circle_fill<span class="badge color-red">5</span></i>
                   <i class="icon material-icons md-only">person<span class="badge color-red">5</span></i>
                 </a>
               </div>

--- a/src/pug/docs/cards.pug
+++ b/src/pug/docs/cards.pug
@@ -469,7 +469,7 @@ block content
                 <small style="opacity: 0.7">Build Mobile Apps</small>
               </div>
               <a href="#" class="link card-close card-opened-fade-in color-white" style="position: absolute; right: 15px; top: 15px">
-                <i class="icon f7-icons">multiply_circle_fill</i>
+                <i class="icon f7-icons">xmark_circle_fill</i>
               </a>
             </div>
             <div class="card-content-padding">
@@ -487,7 +487,7 @@ block content
                 <small style="opacity: 0.7">Build Mobile Apps</small>
               </div>
               <a href="#" class="link card-close card-opened-fade-in color-black" style="position: absolute; right: 15px; top: 15px">
-                <i class="icon f7-icons">multiply_circle_fill</i>
+                <i class="icon f7-icons">xmark_circle_fill</i>
               </a>
             </div>
             <div class="card-content-padding">

--- a/src/pug/docs/data-table.pug
+++ b/src/pug/docs/data-table.pug
@@ -21,7 +21,7 @@ block content
               <table>
                 <thead>
                   <tr>
-                    <th class="label-cell">Desert (100g serving)</th>
+                    <th class="label-cell">Dessert (100g serving)</th>
                     <th class="numeric-cell">Calories</th>
                     ...
                     <th class="medium-only">Comment</th>
@@ -67,7 +67,7 @@ block content
               <table>
                 <thead>
                   <tr>
-                    <th class="label-cell">Desert (100g serving)</th>
+                    <th class="label-cell">Dessert (100g serving)</th>
                     <th class="numeric-cell">Calories</th>
                     <th class="numeric-cell">Fat (g)</th>
                     <th class="numeric-cell">Carbs</th>
@@ -128,7 +128,7 @@ block content
                         <i class="icon-checkbox"></i>
                       </label>
                     </th>
-                    <th class="label-cell">Desert (100g serving)</th>
+                    <th class="label-cell">Dessert (100g serving)</th>
                     <th class="numeric-cell">Calories</th>
                     ...
                     <th class="numeric-cell">Protein (g)</th>
@@ -247,7 +247,7 @@ block content
                           <i class="icon-checkbox"></i>
                         </label>
                       </th>
-                      <th class="label-cell">Desert (100g serving)</th>
+                      <th class="label-cell">Dessert (100g serving)</th>
                       <th class="numeric-cell">Calories</th>
                       ...
                     </tr>
@@ -321,7 +321,7 @@ block content
                           <i class="icon-checkbox"></i>
                         </label>
                       </th>
-                      <th class="label-cell">Desert (100g serving)</th>
+                      <th class="label-cell">Dessert (100g serving)</th>
                       <th class="numeric-cell">Calories</th>
                       ...
                     </tr>
@@ -379,7 +379,7 @@ block content
                           <i class="icon-checkbox"></i>
                         </label>
                       </th>
-                      <th class="label-cell">Desert (100g serving)</th>
+                      <th class="label-cell">Dessert (100g serving)</th>
                       <th class="numeric-cell">Calories</th>
                       ...
                       <th></th>
@@ -443,7 +443,7 @@ block content
                           <i class="icon-checkbox"></i>
                         </label>
                       </th>
-                      <th class="label-cell sortable-cell sortable-cell-active">Desert (100g serving)</th>
+                      <th class="label-cell sortable-cell sortable-cell-active">Dessert (100g serving)</th>
                       <th class="numeric-cell sortable-cell">Calories</th>
                       <th class="numeric-cell sortable-cell">Fat (g)</th>
                       <th class="numeric-cell sortable-cell">Carbs</th>
@@ -499,7 +499,7 @@ block content
                 <table>
                   <thead>
                     <tr>
-                      <th class="label-cell">Desert (100g serving)</th>
+                      <th class="label-cell">Dessert (100g serving)</th>
                       <th class="numeric-cell">Calories</th>
                       ...
                       <th class="numeric-cell">Protein (g)</th>

--- a/src/pug/docs/data-table.pug
+++ b/src/pug/docs/data-table.pug
@@ -227,11 +227,11 @@ block content
                 <!-- Table actions -->
                 <div class="data-table-actions">
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">sort</i>
+                    <i class="icon f7-icons if-not-md">line_horizontal_3_decrease</i>
                     <i class="icon material-icons md-only">sort</i>
                   </a>
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">more_vertical_round</i>
+                    <i class="icon f7-icons if-not-md">ellipsis_vertical_circle</i>
                     <i class="icon material-icons md-only">more_vert</i>
                   </a>
                 </div>
@@ -285,11 +285,11 @@ block content
                   <!-- Default table actions -->
                   <div class="data-table-actions">
                     <a class="link icon-only">
-                      <i class="icon f7-icons if-not-md">sort</i>
+                      <i class="icon f7-icons if-not-md">line_horizontal_3_decrease</i>
                       <i class="icon material-icons md-only">sort</i>
                     </a>
                     <a class="link icon-only">
-                      <i class="icon f7-icons if-not-md">more_vertical_round</i>
+                      <i class="icon f7-icons if-not-md">ellipsis_vertical_circle</i>
                       <i class="icon material-icons md-only">more_vert</i>
                     </a>
                   </div>
@@ -305,7 +305,7 @@ block content
                       <i class="icon material-icons md-only">delete</i>
                     </a>
                     <a class="link icon-only">
-                      <i class="icon f7-icons if-not-md">more_vertical_round</i>
+                      <i class="icon f7-icons if-not-md">ellipsis_vertical_circle</i>
                       <i class="icon material-icons md-only">more_vert</i>
                     </a>
                   </div>
@@ -360,11 +360,11 @@ block content
                 <!-- Table actions -->
                 <div class="data-table-actions">
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">sort</i>
+                    <i class="icon f7-icons if-not-md">line_horizontal_3_decrease</i>
                     <i class="icon material-icons md-only">sort</i>
                   </a>
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">more_vertical_round</i>
+                    <i class="icon f7-icons if-not-md">ellipsis_vertical_circle</i>
                     <i class="icon material-icons md-only">more_vert</i>
                   </a>
                 </div>
@@ -398,7 +398,7 @@ block content
                       ...
                       <td class="actions-cell">
                         <a class="link icon-only">
-                          <i class="icon f7-icons if-not-md">compose</i>
+                          <i class="icon f7-icons if-not-md">square_pencil</i>
                           <i class="icon material-icons md-only">edit</i>
                         </a>
                         <a class="link icon-only">
@@ -424,11 +424,11 @@ block content
                 <div class="data-table-title">Nutrition</div>
                 <div class="data-table-actions">
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">sort</i>
+                    <i class="icon f7-icons if-not-md">line_horizontal_3_decrease</i>
                     <i class="icon material-icons md-only">sort</i>
                   </a>
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">more_vertical_round</i>
+                    <i class="icon f7-icons if-not-md">ellipsis_vertical_circle</i>
                     <i class="icon material-icons md-only">more_vert</i>
                   </a>
                 </div>
@@ -486,11 +486,11 @@ block content
                 <div class="data-table-title">Nutrition</div>
                 <div class="data-table-actions">
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">sort</i>
+                    <i class="icon f7-icons if-not-md">line_horizontal_3_decrease</i>
                     <i class="icon material-icons md-only">sort</i>
                   </a>
                   <a class="link icon-only">
-                    <i class="icon f7-icons if-not-md">more_vertical_round</i>
+                    <i class="icon f7-icons if-not-md">ellipsis_vertical_circle</i>
                     <i class="icon material-icons md-only">more_vert</i>
                   </a>
                 </div>

--- a/src/pug/docs/gauge.pug
+++ b/src/pug/docs/gauge.pug
@@ -184,10 +184,10 @@ block content
           td Dom7 instance with gauge HTML element
         tr
           td gauge.gaugeSvgEl
-          td Gauge generated SVH HTML element
+          td Gauge generated SVG HTML element
         tr
           td gauge.$gaugeSvgEl
-          td Dom7 instance with generated SVH HTML element
+          td Dom7 instance with generated SVG HTML element
         tr
           td gauge.params
           td Gauge parameters

--- a/src/pug/docs/hairlines.pug
+++ b/src/pug/docs/hairlines.pug
@@ -41,9 +41,11 @@ block content
       li `no-hairlines` class on List View and Content Block to remove outer hairlines.
       li `no-hairlines-md` does the same but only for MD theme.
       li `no-hairlines-ios` does the same but only for iOS theme.
+      li `no-hairlines-aurora` does the same but only for Aurora theme.
       li `no-hairlines-between` class on List View to remove hairlines between list items.
       li `no-hairlines-between-md` does the same but only for MD theme.
       li `no-hairlines-between-ios` does the same but only for iOS theme.
+      li `no-hairlines-between-aurora` does the same but only for Aurora theme.
 
     :code(lang="html")
       <!-- remove outer hairlines -->

--- a/src/pug/docs/messages.pug
+++ b/src/pug/docs/messages.pug
@@ -639,7 +639,7 @@ block content
               tailMessageRule: function (message, previousMessage, nextMessage) {
                 // Skip if title
                 if (message.isTitle) return false;
-                  /* if (bascially same as lastMessageRule):
+                  /* if (basically same as lastMessageRule):
                   - there is no next message
                   - or next message type (send/received) is different
                   - or next message sender name is different

--- a/src/pug/docs/navbar.pug
+++ b/src/pug/docs/navbar.pug
@@ -128,7 +128,7 @@ block content
           <div class="left">
             <!-- ... -->
           </div>
-          <!-- usual title will be visible when larget title collapsed -->
+          <!-- usual title will be visible when larger title collapsed -->
           <div class="title">My App</div>
           <div class="right">
             <!-- ... -->

--- a/src/pug/docs/range-slider.pug
+++ b/src/pug/docs/range-slider.pug
@@ -436,7 +436,7 @@ block content
                     </div>
                   </div>
                   <div class="item-cell width-auto flex-shrink-0">
-                    <i class="icon f7-icons if-not-md">sun_max</i>
+                    <i class="icon f7-icons if-not-md">sun_max_fill</i>
                     <i class="icon material-icons md-only">brightness_high</i>
                   </div>
                 </li>
@@ -448,7 +448,7 @@ block content
               <ul>
                 <li class="item-row">
                   <div class="item-cell width-auto flex-shrink-0">
-                    <i class="icon f7-icons if-not-md">money_dollar_round</i>
+                    <i class="icon f7-icons if-not-md">money_dollar_circle</i>
                     <i class="icon material-icons md-only">attach_money</i>
                   </div>
                   <div class="item-cell item-cell-shrink-3">
@@ -466,7 +466,7 @@ block content
                     ></div>
                   </div>
                   <div class="item-cell width-auto flex-shrink-0">
-                    <i class="icon f7-icons if-not-md">money_dollar_round_fill</i>
+                    <i class="icon f7-icons if-not-md">money_dollar_circle_fill</i>
                     <i class="icon material-icons md-only">monetization_on</i>
                   </div>
                 </li>

--- a/src/pug/docs/stepper.pug
+++ b/src/pug/docs/stepper.pug
@@ -230,7 +230,7 @@ block content
           td manualInputMode
           td boolean
           td false
-          td Enables manual input mode. This mode allows to type value from keyboar and check fractional part with defined accurancy. Also, `step` parameter is ignored when typing in this mode.
+          td Enables manual input mode. This mode allows to type value from keyboard and check fractional part with defined accurancy. Also, `step` parameter is ignored when typing in this mode.
         tr
           td decimalPoint
           td number
@@ -939,7 +939,7 @@ block content
               </ul>
             </div>
       h4 Manual input
-      p It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboar and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.
+      p It is possible to enter value manually from keyboard or mobile keypad. When click on input field, stepper enter into manual input mode, which allow type value from keyboard and check fractional part with defined accurancy. Click outside or enter Return key, ending manual mode.
       :code(lang="html")
             <div class="block block-strong text-align-center">
               <div class="row">

--- a/src/pug/docs/subnavbar.pug
+++ b/src/pug/docs/subnavbar.pug
@@ -107,7 +107,7 @@ block content
           </div>
 
     h4 With Title
-    p We can alos use special `subnavbar-title` element to use Subnavbar to display larget title:
+    p We can also use special `subnavbar-title` element to use Subnavbar to display larget title:
     :code(lang="html")
       ...
       <div class="subnavbar">

--- a/src/pug/docs/subnavbar.pug
+++ b/src/pug/docs/subnavbar.pug
@@ -107,7 +107,7 @@ block content
           </div>
 
     h4 With Title
-    p We can also use special `subnavbar-title` element to use Subnavbar to display larget title:
+    p We can also use special `subnavbar-title` element to use Subnavbar to display larger title:
     :code(lang="html")
       ...
       <div class="subnavbar">

--- a/src/pug/docs/treeview.pug
+++ b/src/pug/docs/treeview.pug
@@ -419,7 +419,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">cv.docx</div>
                   </div>
                 </div>
@@ -427,7 +427,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">info.docx</div>
                   </div>
                 </div>
@@ -445,7 +445,7 @@ block content
           <div class="treeview-item">
             <div class="treeview-item-root">
               <div class="treeview-item-content">
-                <i class="icon f7-icons">document_text_fill</i>
+                <i class="icon f7-icons">doc_text_fill</i>
                 <div class="treeview-item-label">index.html</div>
               </div>
             </div>
@@ -513,7 +513,7 @@ block content
                       <input type="checkbox">
                       <i class="icon-checkbox"></i>
                     </label>
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">cv.docx</div>
                   </div>
                 </div>
@@ -525,7 +525,7 @@ block content
                       <input type="checkbox">
                       <i class="icon-checkbox"></i>
                     </label>
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">info.docx</div>
                   </div>
                 </div>
@@ -551,7 +551,7 @@ block content
                   <input type="checkbox">
                   <i class="icon-checkbox"></i>
                 </label>
-                <i class="icon f7-icons">document_text_fill</i>
+                <i class="icon f7-icons">doc_text_fill</i>
                 <div class="treeview-item-label">index.html</div>
               </div>
             </div>
@@ -599,7 +599,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">cv.docx</div>
                   </div>
                 </div>
@@ -607,7 +607,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">info.docx</div>
                   </div>
                 </div>
@@ -625,7 +625,7 @@ block content
           <div class="treeview-item">
             <div class="treeview-item-root">
               <div class="treeview-item-content">
-                <i class="icon f7-icons">document_text_fill</i>
+                <i class="icon f7-icons">doc_text_fill</i>
                 <div class="treeview-item-label">index.html</div>
               </div>
             </div>
@@ -673,7 +673,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root treeview-item-selectable">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">cv.docx</div>
                   </div>
                 </div>
@@ -681,7 +681,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root treeview-item-selectable">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">document_text_fill</i>
+                    <i class="icon f7-icons">doc_text_fill</i>
                     <div class="treeview-item-label">info.docx</div>
                   </div>
                 </div>
@@ -699,7 +699,7 @@ block content
           <div class="treeview-item">
             <div class="treeview-item-root treeview-item-selectable">
               <div class="treeview-item-content">
-                <i class="icon f7-icons">document_text_fill</i>
+                <i class="icon f7-icons">doc_text_fill</i>
                 <div class="treeview-item-label">index.html</div>
               </div>
             </div>
@@ -722,7 +722,7 @@ block content
             <div class="treeview-item-root">
               <div class="treeview-toggle"></div>
               <div class="treeview-item-content">
-                <i class="icon f7-icons">persons</i>
+                <i class="icon f7-icons">person_2_fill</i>
                 <div class="treeview-item-label">Users</div>
               </div>
             </div>
@@ -731,7 +731,7 @@ block content
               <div class="treeview-item">
                 <div class="treeview-item-root">
                   <div class="treeview-item-content">
-                    <i class="icon f7-icons">person</i>
+                    <i class="icon f7-icons">person_fill</i>
                     <div class="treeview-item-label">{{name}}</div>
                   </div>
                 </div>
@@ -780,7 +780,7 @@ block content
             <div class="treeview-item-root treeview-item-toggle">
               <div class="treeview-toggle"></div>
               <div class="treeview-item-content">
-                <i class="icon f7-icons">data_fill</i>
+                <i class="icon f7-icons">square_grid_2x2_fill</i>
                 <div class="treeview-item-label">Modals</div>
               </div>
             </div>
@@ -815,7 +815,7 @@ block content
             <div class="treeview-item-root treeview-item-toggle">
               <div class="treeview-toggle"></div>
               <div class="treeview-item-content">
-                <i class="icon f7-icons">data_fill</i>
+                <i class="icon f7-icons">square_grid_2x2_fill</i>
                 <div class="treeview-item-label">Navigation Bars</div>
               </div>
             </div>

--- a/src/pug/react/badge.pug
+++ b/src/pug/react/badge.pug
@@ -47,7 +47,7 @@ block content
                 <Navbar sliding title="Badge">
                   <NavRight>
                     <Link iconOnly>
-                      <Icon ios="f7:person_fill" aurora="f7:person_fill" md="material:person">
+                      <Icon ios="f7:person_circle_fill" aurora="f7:person_circle_fill" md="material:person">
                         <Badge color="red">5</Badge>
                       </Icon>
                     </Link>

--- a/src/pug/react/cards.pug
+++ b/src/pug/react/cards.pug
@@ -305,7 +305,7 @@ block content
                 <br />
                 <small style={{opacity: 0.7}}>Build Mobile Apps</small>
               </CardHeader>
-              <Link cardClose color="white" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="multiply_circle_fill" />
+              <Link cardClose color="white" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="xmark_circle_fill" />
             </div>
             <div className="card-content-padding">
               <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel...</p>
@@ -321,7 +321,7 @@ block content
                 <br/>
                 <small style={{opacity: 0.7}}>Build Mobile Apps</small>
               </CardHeader>
-              <Link cardClose color="black" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="multiply_circle_fill" />
+              <Link cardClose color="black" className="card-opened-fade-in" style={{position: 'absolute', right: '15px', top: '15px'}} iconF7="xmark_circle_fill" />
             </div>
             <div className="card-content-padding">
               <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel...</p>

--- a/src/pug/react/grid.pug
+++ b/src/pug/react/grid.pug
@@ -64,6 +64,11 @@ block content
         tr
           th(colspan="4") &lt;Col&gt; properties
         tr
+          td tag
+          td string
+          td div
+          td Defines which tag must be used to render column element
+        tr
           td width
           td number<br>string
           td auto

--- a/src/pug/react/list-view.pug
+++ b/src/pug/react/list-view.pug
@@ -165,6 +165,11 @@ block content
           td false
           td Removes outer <a href="../docs/hairlines.html">hairlines</a> for iOS theme
         tr
+          td noHairlinesAurora
+          td boolean
+          td false
+          td Removes outer <a href="../docs/hairlines.html">hairlines</a> for Aurora theme
+        tr
           td noHairlinesBetween
           td boolean
           td false
@@ -179,6 +184,11 @@ block content
           td boolean
           td false
           td Removes inner <a href="../docs/hairlines.html">hairlines</a> between items for iOS theme
+        tr
+          td noHairlinesBetweenAurora
+          td boolean
+          td false
+          td Removes inner <a href="../docs/hairlines.html">hairlines</a> between items for Aurora theme
         tr
           td tab
           td boolean

--- a/src/pug/react/range-slider.pug
+++ b/src/pug/react/range-slider.pug
@@ -221,7 +221,7 @@ block content
                       ></Range>
                     </ListItemCell>
                     <ListItemCell className="width-auto flex-shrink-0">
-                      <Icon ios="f7:sun_max" aurora="f7:sun_max" md="material:brightness_high"></Icon>
+                      <Icon ios="f7:sun_max_fill" aurora="f7:sun_max_fill" md="material:brightness_high"></Icon>
                     </ListItemCell>
                   </ListItem>
                 </List>
@@ -230,7 +230,7 @@ block content
                 <List simpleList>
                   <ListItem>
                     <ListItemCell className="width-auto flex-shrink-0">
-                      <Icon ios="f7:money_dollar_round" aurora="f7:money_dollar_round" md="material:attach_money"></Icon>
+                      <Icon ios="f7:money_dollar_circle" aurora="f7:money_dollar_circle" md="material:attach_money"></Icon>
                     </ListItemCell>
                     <ListItemCell className="flex-shrink-3">
                       <Range
@@ -245,7 +245,7 @@ block content
                       ></Range>
                     </ListItemCell>
                     <ListItemCell className="width-auto flex-shrink-0">
-                      <Icon ios="f7:money_dollar_round_fill" aurora="f7:money_dollar_round_fill" md="material:monetization_on"></Icon>
+                      <Icon ios="f7:money_dollar_circle_fill" aurora="f7:money_dollar_circle_fill" md="material:monetization_on"></Icon>
                     </ListItemCell>
                   </ListItem>
                 </List>

--- a/src/pug/react/skeleton.pug
+++ b/src/pug/react/skeleton.pug
@@ -35,17 +35,17 @@ block content
           td width
           td string<br>number
           td
-          td Skeleton text element width
+          td Skeleton block element width
         tr
           td height
           td string<br>number
           td
-          td Skeleton text element height
+          td Skeleton block element height
         tr
           td tag
           td string
-          td span
-          td Skeleton text element tag
+          td div
+          td Skeleton block element tag
 
         tr
           th(colspan="4") &lt;SkeletonText&gt; properties

--- a/src/pug/react/skeleton.pug
+++ b/src/pug/react/skeleton.pug
@@ -35,17 +35,17 @@ block content
           td width
           td string<br>number
           td
-          td Skeleton block element width
+          td Skeleton block width
         tr
           td height
           td string<br>number
           td
-          td Skeleton block element height
+          td Skeleton block height
         tr
           td tag
           td string
           td div
-          td Skeleton block element tag
+          td Skeleton block tag
 
         tr
           th(colspan="4") &lt;SkeletonText&gt; properties

--- a/src/pug/react/treeview.pug
+++ b/src/pug/react/treeview.pug
@@ -252,11 +252,11 @@ block content
                       <TreeviewItem label="background.jpg" iconF7="photo_fill" />
                     </TreeviewItem>
                     <TreeviewItem label="documents" iconF7="folder_fill">
-                      <TreeviewItem label="cv.docx" iconF7="document_text_fill" />
-                      <TreeviewItem label="info.docx" iconF7="document_text_fill" />
+                      <TreeviewItem label="cv.docx" iconF7="doc_text_fill" />
+                      <TreeviewItem label="info.docx" iconF7="doc_text_fill" />
                     </TreeviewItem>
                     <TreeviewItem label=".gitignore" iconF7="logo_github" />
-                    <TreeviewItem label="index.html" iconF7="document_text_fill" />
+                    <TreeviewItem label="index.html" iconF7="doc_text_fill" />
                   </Treeview>
                 </Block>
 
@@ -300,7 +300,7 @@ block content
                           this.setState({...this.state});
                         }}
                       />
-                      <TreeviewItem label="cv.docx" iconF7="document_text_fill">
+                      <TreeviewItem label="cv.docx" iconF7="doc_text_fill">
                         <Checkbox slot="content-start"
                           checked={this.state.checkboxes.documents['cv.docx']}
                           onChange={(e) => {
@@ -309,7 +309,7 @@ block content
                           }}
                         />
                       </TreeviewItem>
-                      <TreeviewItem label="info.docx" iconF7="document_text_fill">
+                      <TreeviewItem label="info.docx" iconF7="doc_text_fill">
                         <Checkbox slot="content-start"
                           checked={this.state.checkboxes.documents['info.docx']}
                           onChange={(e) => {
@@ -325,7 +325,7 @@ block content
                         this.setState({...this.state});
                       }}/>
                     </TreeviewItem>
-                    <TreeviewItem label="index.html" iconF7="document_text_fill">
+                    <TreeviewItem label="index.html" iconF7="doc_text_fill">
                       <Checkbox slot="content-start" checked={this.state.checkboxes['index.html']} onChange={(e) => {
                         this.state.checkboxes['index.html'] = e.target.checked;
                         this.setState({...this.state});
@@ -342,11 +342,11 @@ block content
                       <TreeviewItem label="background.jpg" iconF7="photo_fill" />
                     </TreeviewItem>
                     <TreeviewItem itemToggle label="documents" iconF7="folder_fill">
-                      <TreeviewItem label="cv.docx" iconF7="document_text_fill" />
-                      <TreeviewItem label="info.docx" iconF7="document_text_fill" />
+                      <TreeviewItem label="cv.docx" iconF7="doc_text_fill" />
+                      <TreeviewItem label="info.docx" iconF7="doc_text_fill" />
                     </TreeviewItem>
                     <TreeviewItem label=".gitignore" iconF7="logo_github" />
-                    <TreeviewItem label="index.html" iconF7="document_text_fill" />
+                    <TreeviewItem label="index.html" iconF7="doc_text_fill" />
                   </Treeview>
                 </Block>
 
@@ -386,14 +386,14 @@ block content
                         selectable
                         selected={this.state.selectedItem === 'cv.docx'}
                         label="cv.docx"
-                        iconF7="document_text_fill"
+                        iconF7="doc_text_fill"
                         onClick={(e) => this.toggleSelectable(e, 'cv.docx')}
                       />
                       <TreeviewItem
                         selectable
                         selected={this.state.selectedItem === 'info.docx'}
                         label="info.docx"
-                        iconF7="document_text_fill"
+                        iconF7="doc_text_fill"
                         onClick={(e) => this.toggleSelectable(e, 'info.docx')}
                       />
                     </TreeviewItem>
@@ -408,7 +408,7 @@ block content
                       selectable
                       selected={this.state.selectedItem === 'index.html'}
                       label="index.html"
-                      iconF7="document_text_fill"
+                      iconF7="doc_text_fill"
                       onClick={(e) => this.toggleSelectable(e, 'index.html')}
                     />
                   </Treeview>
@@ -420,14 +420,14 @@ block content
                     <TreeviewItem
                       toggle
                       loadChildren
-                      iconF7="persons"
+                      iconF7="person_2_fill"
                       label="Users"
                       onTreeviewLoadChildren={(e, done) => this.loadChildren(done)}
                     >
                       {this.state.loadedChildren.map((item, index) => (
                         <TreeviewItem
                           key={index}
-                          iconF7="person"
+                          iconF7="person_fill"
                           label={item.name}
                         />
                       ))}
@@ -438,12 +438,12 @@ block content
                 <BlockTitle>With links</BlockTitle>
                 <Block strong className="no-padding-horizontal">
                   <Treeview>
-                    <TreeviewItem iconF7="data_fill" itemToggle label="Modals">
+                    <TreeviewItem iconF7="square_grid_2x2_fill" itemToggle label="Modals">
                       <TreeviewItem link="/popup/" iconF7="link" label="Popup" />
                       <TreeviewItem link="/dialog/" iconF7="link" label="Dialog" />
                       <TreeviewItem link="/action-sheet/" iconF7="link" label="Action Sheet" />
                     </TreeviewItem>
-                    <TreeviewItem iconF7="data_fill" itemToggle label="Navigation Bars">
+                    <TreeviewItem iconF7="square_grid_2x2_fill" itemToggle label="Navigation Bars">
                       <TreeviewItem link="/navbar/" iconF7="link" label="Navbar" />
                       <TreeviewItem link="/toolbar-tabbar/" iconF7="link" label="Toolbar & Tabbar" />
                     </TreeviewItem>

--- a/src/pug/svelte/grid.pug
+++ b/src/pug/svelte/grid.pug
@@ -67,7 +67,7 @@ block content
           td tag
           td string
           td div
-          td Defines which tag must be used to render row element. Can be `div` or `span`
+          td Defines which tag must be used to render column element. Can be `div` or `span`
         tr
           td width
           td number<br>string

--- a/src/pug/svelte/list-view.pug
+++ b/src/pug/svelte/list-view.pug
@@ -170,6 +170,11 @@ block content
           td false
           td Removes outer <a href="../docs/hairlines.html">hairlines</a> for iOS theme
         tr
+          td noHairlinesAurora
+          td boolean
+          td false
+          td Removes outer <a href="../docs/hairlines.html">hairlines</a> for Aurora theme
+        tr
           td noHairlinesBetween
           td boolean
           td false
@@ -184,6 +189,11 @@ block content
           td boolean
           td false
           td Removes inner <a href="../docs/hairlines.html">hairlines</a> between items for iOS theme
+        tr
+          td noHairlinesBetweenAurora
+          td boolean
+          td false
+          td Removes inner <a href="../docs/hairlines.html">hairlines</a> between items for Aurora theme
         tr
           td tab
           td boolean

--- a/src/pug/svelte/range-slider.pug
+++ b/src/pug/svelte/range-slider.pug
@@ -210,7 +210,7 @@ block content
                 ></Range>
               </ListItemCell>
               <ListItemCell class="width-auto flex-shrink-0">
-                <Icon ios="f7:sun_max" aurora="f7:sun_max" md="material:brightness_high"></Icon>
+                <Icon ios="f7:sun_max_fill" aurora="f7:sun_max_fill" md="material:brightness_high"></Icon>
               </ListItemCell>
             </ListItem>
           </List>
@@ -222,7 +222,7 @@ block content
           <List simpleList>
             <ListItem>
               <ListItemCell class="width-auto flex-shrink-0">
-                <Icon ios="f7:money_dollar_round" aurora="f7:money_dollar_round" md="material:attach_money"></Icon>
+                <Icon ios="f7:money_dollar_circle" aurora="f7:money_dollar_circle" md="material:attach_money"></Icon>
               </ListItemCell>
               <ListItemCell class="flex-shrink-3">
                 <Range
@@ -237,7 +237,7 @@ block content
                 ></Range>
               </ListItemCell>
               <ListItemCell class="width-auto flex-shrink-0">
-                <Icon ios="f7:money_dollar_round_fill" aurora="f7:money_dollar_round_fill" md="material:monetization_on"></Icon>
+                <Icon ios="f7:money_dollar_circle_fill" aurora="f7:money_dollar_circle_fill" md="material:monetization_on"></Icon>
               </ListItemCell>
             </ListItem>
           </List>

--- a/src/pug/vue/badge.pug
+++ b/src/pug/vue/badge.pug
@@ -46,7 +46,7 @@ block content
               <f7-navbar sliding title="Badge">
                 <f7-nav-right>
                   <f7-link icon-only>
-                    <f7-icon ios="f7:person_fill" aurora="f7:person_fill" md="material:person" class="icon f7-icons ios-only">
+                    <f7-icon ios="f7:person_circle_fill" aurora="f7:person_circle_fill" md="material:person" class="icon f7-icons ios-only">
                       <f7-badge color="red">5</f7-badge>
                     </f7-icon>
                   </f7-link>

--- a/src/pug/vue/cards.pug
+++ b/src/pug/vue/cards.pug
@@ -299,7 +299,7 @@ block content
                 <br />
                 <small :style="{opacity: 0.7}">Build Mobile Apps</small>
               </f7-card-header>
-              <f7-link card-close color="white" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="multiply_circle_fill"></f7-link>
+              <f7-link card-close color="white" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="xmark_circle_fill"></f7-link>
             </div>
             <div class="card-content-padding">
               <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel...</p>
@@ -315,7 +315,7 @@ block content
                 <br/>
                 <small :style="{opacity: 0.7}">Build Mobile Apps</small>
               </f7-card-header>
-              <f7-link card-close color="black" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="multiply_circle_fill"></f7-link>
+              <f7-link card-close color="black" class="card-opened-fade-in" :style="{position: 'absolute', right: '15px', top: '15px'}" icon-f7="xmark_circle_fill"></f7-link>
             </div>
             <div class="card-content-padding">
               <p>Framework7 - is a free and open source HTML mobile framework to develop hybrid mobile apps or web apps with iOS or Android (Material) native look and feel...</p>

--- a/src/pug/vue/grid.pug
+++ b/src/pug/vue/grid.pug
@@ -64,6 +64,11 @@ block content
         tr
           th(colspan="4") &lt;f7-col&gt; properties
         tr
+          td tag
+          td string
+          td div
+          td Defines which tag must be used to render column element          
+        tr
           td width
           td number<br>string
           td auto

--- a/src/pug/vue/list-view.pug
+++ b/src/pug/vue/list-view.pug
@@ -165,6 +165,11 @@ block content
           td false
           td Removes outer <a href="../docs/hairlines.html">hairlines</a> for iOS theme
         tr
+          td no-hairlines-aurora
+          td boolean
+          td false
+          td Removes outer <a href="../docs/hairlines.html">hairlines</a> for Aurora theme
+        tr
           td no-hairlines-between
           td boolean
           td false
@@ -179,6 +184,11 @@ block content
           td boolean
           td false
           td Removes inner <a href="../docs/hairlines.html">hairlines</a> between items for iOS theme
+        tr
+          td no-hairlines-between-aurora
+          td boolean
+          td false
+          td Removes inner <a href="../docs/hairlines.html">hairlines</a> between items for Aurora theme
         tr
           td tab
           td boolean

--- a/src/pug/vue/range-slider.pug
+++ b/src/pug/vue/range-slider.pug
@@ -209,7 +209,7 @@ block content
                   ></f7-range>
                 </f7-list-item-cell>
                 <f7-list-item-cell class="width-auto flex-shrink-0">
-                  <f7-icon ios="f7:sun_max" aurora="f7:sun_max" md="material:brightness_high"></f7-icon>
+                  <f7-icon ios="f7:sun_max_fill" aurora="f7:sun_max_fill" md="material:brightness_high"></f7-icon>
                 </f7-list-item-cell>
               </f7-list-item>
             </f7-list>
@@ -218,7 +218,7 @@ block content
             <f7-list simple-list>
               <f7-list-item>
                 <f7-list-item-cell class="width-auto flex-shrink-0">
-                  <f7-icon ios="f7:money_dollar_round" aurora="f7:money_dollar_round" md="material:attach_money"></f7-icon>
+                  <f7-icon ios="f7:money_dollar_circle" aurora="f7:money_dollar_circle" md="material:attach_money"></f7-icon>
                 </f7-list-item-cell>
                 <f7-list-item-cell class="flex-shrink-3">
                   <f7-range
@@ -233,7 +233,7 @@ block content
                   ></f7-range>
                 </f7-list-item-cell>
                 <f7-list-item-cell class="width-auto flex-shrink-0">
-                  <f7-icon ios="f7:money_dollar_round_fill" aurora="f7:money_dollar_round_fill" md="material:monetization_on"></f7-icon>
+                  <f7-icon ios="f7:money_dollar_circle_fill" aurora="f7:money_dollar_circle_fill" md="material:monetization_on"></f7-icon>
                 </f7-list-item-cell>
               </f7-list-item>
             </f7-list>

--- a/src/pug/vue/treeview.pug
+++ b/src/pug/vue/treeview.pug
@@ -199,11 +199,11 @@ block content
                   <f7-treeview-item label="background.jpg" icon-f7="photo_fill" />
                 </f7-treeview-item>
                 <f7-treeview-item label="documents" icon-f7="folder_fill">
-                  <f7-treeview-item label="cv.docx" icon-f7="document_text_fill" />
-                  <f7-treeview-item label="info.docx" icon-f7="document_text_fill" />
+                  <f7-treeview-item label="cv.docx" icon-f7="doc_text_fill" />
+                  <f7-treeview-item label="info.docx" icon-f7="doc_text_fill" />
                 </f7-treeview-item>
                 <f7-treeview-item label=".gitignore" icon-f7="logo_github" />
-                <f7-treeview-item label="index.html" icon-f7="document_text_fill" />
+                <f7-treeview-item label="index.html" icon-f7="doc_text_fill" />
               </f7-treeview>
             </f7-block>
 
@@ -235,13 +235,13 @@ block content
                     :indeterminate="Object.values(checkboxes.documents).indexOf(false) >= 0 && Object.values(checkboxes.documents).indexOf(true) >= 0"
                     @change="(e) => Object.keys(checkboxes.documents).forEach(k => checkboxes.documents[k] = e.target.checked)"
                   />
-                  <f7-treeview-item label="cv.docx" icon-f7="document_text_fill">
+                  <f7-treeview-item label="cv.docx" icon-f7="doc_text_fill">
                     <f7-checkbox slot="content-start"
                       :checked="checkboxes.documents['cv.docx']"
                       @change="checkboxes.documents['cv.docx'] = $event.target.checked"
                     />
                   </f7-treeview-item>
-                  <f7-treeview-item label="info.docx" icon-f7="document_text_fill">
+                  <f7-treeview-item label="info.docx" icon-f7="doc_text_fill">
                     <f7-checkbox slot="content-start"
                       :checked="checkboxes.documents['info.docx']"
                       @change="checkboxes.documents['info.docx'] = $event.target.checked"
@@ -254,7 +254,7 @@ block content
                     @change="checkboxes['.gitignore'] = $event.target.checked"
                   />
                 </f7-treeview-item>
-                <f7-treeview-item label="index.html" icon-f7="document_text_fill">
+                <f7-treeview-item label="index.html" icon-f7="doc_text_fill">
                   <f7-checkbox slot="content-start"
                     :checked="checkboxes['index.html']"
                     @change="checkboxes['index.html'] = $event.target.checked"
@@ -271,11 +271,11 @@ block content
                   <f7-treeview-item label="background.jpg" icon-f7="photo_fill" />
                 </f7-treeview-item>
                 <f7-treeview-item item-toggle label="documents" icon-f7="folder_fill">
-                  <f7-treeview-item label="cv.docx" icon-f7="document_text_fill" />
-                  <f7-treeview-item label="info.docx" icon-f7="document_text_fill" />
+                  <f7-treeview-item label="cv.docx" icon-f7="doc_text_fill" />
+                  <f7-treeview-item label="info.docx" icon-f7="doc_text_fill" />
                 </f7-treeview-item>
                 <f7-treeview-item label=".gitignore" icon-f7="logo_github" />
-                <f7-treeview-item label="index.html" icon-f7="document_text_fill" />
+                <f7-treeview-item label="index.html" icon-f7="doc_text_fill" />
               </f7-treeview>
             </f7-block>
 
@@ -315,14 +315,14 @@ block content
                     selectable
                     :selected="selectedItem === 'cv.docx'"
                     label="cv.docx"
-                    icon-f7="document_text_fill"
+                    icon-f7="doc_text_fill"
                     @click="toggleSelectable($event, 'cv.docx')"
                   />
                   <f7-treeview-item
                     selectable
                     :selected="selectedItem === 'info.docx'"
                     label="info.docx"
-                    icon-f7="document_text_fill"
+                    icon-f7="doc_text_fill"
                     @click="toggleSelectable($event, 'info.docx')"
                   />
                 </f7-treeview-item>
@@ -337,7 +337,7 @@ block content
                   selectable
                   :selected="selectedItem === 'index.html'"
                   label="index.html"
-                  icon-f7="document_text_fill"
+                  icon-f7="doc_text_fill"
                   @click="toggleSelectable($event, 'index.html')"
                 />
               </f7-treeview>
@@ -349,14 +349,14 @@ block content
                 <f7-treeview-item
                   toggle
                   load-children
-                  icon-f7="persons"
+                  icon-f7="person_2_fill"
                   label="Users"
                   @treeview:loadchildren="loadChildren"
                 >
                   <f7-treeview-item
                     v-for="(item, index) in loadedChildren"
                     :key="index"
-                    icon-f7="person"
+                    icon-f7="person_fill"
                     :label="item.name"
                   />
                 </f7-treeview-item>
@@ -366,12 +366,12 @@ block content
             <f7-block-title>With links</f7-block-title>
             <f7-block strong class="no-padding-horizontal">
               <f7-treeview>
-                <f7-treeview-item icon-f7="data_fill" item-toggle label="Modals">
+                <f7-treeview-item icon-f7="square_grid_2x2_fill" item-toggle label="Modals">
                   <f7-treeview-item link="/popup/" icon-f7="link" label="Popup" />
                   <f7-treeview-item link="/dialog/" icon-f7="link" label="Dialog" />
                   <f7-treeview-item link="/action-sheet/" icon-f7="link" label="Action Sheet" />
                 </f7-treeview-item>
-                <f7-treeview-item icon-f7="data_fill" item-toggle label="Navigation Bars">
+                <f7-treeview-item icon-f7="square_grid_2x2_fill" item-toggle label="Navigation Bars">
                   <f7-treeview-item link="/navbar/" icon-f7="link" label="Navbar" />
                   <f7-treeview-item link="/toolbar-tabbar/" icon-f7="link" label="Toolbar & Tabbar" />
                 </f7-treeview-item>


### PR DESCRIPTION
Fixed typo in stepper pages and docs

And fixed small typo and icons in data table demos and docs

And icons in range slider, appbar, badge, cards, toolbar/tabbar, treeview demos and docs

And fixed small typo in subnavbar and navbar pages, gauge docs, messages demos and docs, skeleton React docs, hairlines docs and _mixins.pug

And fixed column properties in grid and list properties in list-view for React/Svelte/Vue docs