### PR TITLE
Picker does not have an addValue method

### DIFF
--- a/src/pug/docs/picker.pug
+++ b/src/pug/docs/picker.pug
@@ -345,9 +345,6 @@ block content
           td picker.getValue()
           td Returns current picker value
         tr
-          td picker.addValue()
-          td Adds value to the values array. Useful in case if multiple selection is enabled (with `multiple: true` parameter)
-        tr
           td picker.open()
           td Open Picker
         tr


### PR DESCRIPTION
On the "Picker" page of the documentation, there is also addValue in the method list:

https://github.com/framework7io/framework7-website/blob/2f3a2d71f8e7898dca2c7d9b669e86c53a87afd1/src/pug/docs/picker.pug#L347-L349

But this method doesn't exist in

https://github.com/framework7io/framework7/blob/master/src/core/components/picker/picker-class.js

Fix #426 