### PR TITLE
Update app.panel parameters for v5 docs

### DIFF
--- a/src/pug/docs/app.pug
+++ b/src/pug/docs/app.pug
@@ -18,7 +18,7 @@ block content
             id: 'com.myapp.test',
             // Enable swipe panel
             panel: {
-              swipe: 'left',
+              swipe: true,
             },
             // ... other parameters
           });
@@ -289,9 +289,8 @@ block content
             id: 'com.myapp.test',
             // Extended by Panel component:
             panel: {
-              swipe: 'left',
-              leftBreakpoint: 768,
-              rightBreakpoint: 1024,
+              swipe: true,
+              visibleBreakpoint: 1024,
             },
             // Extended by Dialog component:
             dialog: {

--- a/src/pug/docs/init-app.pug
+++ b/src/pug/docs/init-app.pug
@@ -24,7 +24,7 @@ block content
             id: 'com.myapp.test',
             // Enable swipe panel
             panel: {
-              swipe: 'left',
+              swipe: true,
             },
             // Add default routes
             routes: [
@@ -50,7 +50,7 @@ block content
             id: 'com.myapp.test',
             // Enable swipe panel
             panel: {
-              swipe: 'left',
+              swipe: true,
             },
             // Add default routes
             routes: [


### PR DESCRIPTION
In the release notes of version 5 it is written that:

https://github.com/framework7io/framework7-website/blob/1618cb4d2f61553d5e8e01b083e6cf8c1de8b7c7/src/CHANGELOG.md#L702-L704

but in "App / Core" page and "Initialize App" page there are still code examples that use the parameters that have been removed.

Fix #421 