### PR TITLE
The minimal-ui viewport property is no longer supported in iOS 8+

### DIFF
--- a/src/pug/docs-demos/core/_layout.pug
+++ b/src/pug/docs-demos/core/_layout.pug
@@ -3,7 +3,7 @@ doctype
 html
   head
     meta(charset="utf-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover")
+    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover")
     meta(name='apple-mobile-web-app-capable', content='yes')
     meta(name="apple-mobile-web-app-status-bar-style", content="black")
     title My App

--- a/src/pug/docs-demos/react/_layout.pug
+++ b/src/pug/docs-demos/react/_layout.pug
@@ -3,7 +3,7 @@ doctype
 html
   head
     meta(charset="utf-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover")
+    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover")
     meta(name='apple-mobile-web-app-capable', content='yes')
     meta(name="apple-mobile-web-app-status-bar-style", content="black")
     title My App

--- a/src/pug/docs-demos/svelte/_layout.pug
+++ b/src/pug/docs-demos/svelte/_layout.pug
@@ -2,7 +2,7 @@ doctype
 html
   head
     meta(charset="utf-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover")
+    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover")
     meta(name='apple-mobile-web-app-capable', content='yes')
     meta(name="apple-mobile-web-app-status-bar-style", content="black")
     title My App

--- a/src/pug/docs-demos/vue/_layout.pug
+++ b/src/pug/docs-demos/vue/_layout.pug
@@ -3,7 +3,7 @@ doctype
 html
   head
     meta(charset="utf-8")
-    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover")
+    meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover")
     meta(name='apple-mobile-web-app-capable', content='yes')
     meta(name="apple-mobile-web-app-status-bar-style", content="black")
     title My App

--- a/src/pug/docs/app-layout.pug
+++ b/src/pug/docs/app-layout.pug
@@ -16,7 +16,7 @@ block content
         <head>
           <!-- Required meta tags-->
           <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
           <meta name="apple-mobile-web-app-capable" content="yes">
           <!-- Color theme for statusbar (Android only) -->
           <meta name="theme-color" content="#2196f3">

--- a/src/pug/react/app-layout.pug
+++ b/src/pug/react/app-layout.pug
@@ -17,7 +17,7 @@ block content
         <head>
           <!-- Required meta tags-->
           <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
           <meta name="apple-mobile-web-app-capable" content="yes">
           <!-- Color theme for statusbar (Android only) -->
           <meta name="theme-color" content="#2196f3">

--- a/src/pug/svelte/app-layout.pug
+++ b/src/pug/svelte/app-layout.pug
@@ -17,7 +17,7 @@ block content
         <head>
           <!-- Required meta tags-->
           <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
           <meta name="apple-mobile-web-app-capable" content="yes">
           <!-- Color theme for statusbar (Android only) -->
           <meta name="theme-color" content="#2196f3">

--- a/src/pug/vue/app-layout.pug
+++ b/src/pug/vue/app-layout.pug
@@ -17,7 +17,7 @@ block content
             <head>
               <!-- Required meta tags-->
               <meta charset="utf-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
+              <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
               <meta name="apple-mobile-web-app-capable" content="yes">
               <!-- Color theme for statusbar (Android only) -->
               <meta name="theme-color" content="#2196f3">


### PR DESCRIPTION
In [iOS 8 release notes](https://developer.apple.com/library/archive/releasenotes/General/RN-iOSSDK-8.0/) is reported:

- The `minimal-ui` viewport property is no longer supported in iOS 8.

So I thought about removing it from the layouts.

I noticed that it has also been removed from KS since the version included in f7 v2.