### PR TITLE
Added `photobrowser:beforedestroy` event to photo-browser.pug

### DIFF
--- a/src/pug/docs/photo-browser.pug
+++ b/src/pug/docs/photo-browser.pug
@@ -394,6 +394,10 @@ block content
           td photobrowser:closed
           td Photo Browser Element
           td Event will be triggered after Photo Browser completes its closing animation
+        tr
+          td photobrowser:beforedestroy
+          td Photo Browser Element
+          td Event will be triggered right before Photo Browser instance will be destroyed
     h3 App and Photo Browser Instance Events
     p Photo Browser instance emits events on both self instance and app instance. App instance events has same names prefixed with `photoBrowser`.
     table.events-table

--- a/src/pug/docs/photo-browser.pug
+++ b/src/pug/docs/photo-browser.pug
@@ -178,6 +178,11 @@ block content
                     },
                   },
         tr
+          td virtualSlides
+          td boolean
+          td true
+          td When enabled then Swiper will use Virtual Slides
+        tr
           th(colspan="4") Render functions
         tr
           td renderNavbar


### PR DESCRIPTION
Update photo-browser.pug

Also added `virtualSlides` property

(@nolimits4web A curiosity, in the Vue version the property name must be reported as `virtualSlides`

https://github.com/framework7io/framework7-website/blob/111c8af323a53882be2cc8af8a5dbf2b1734dc5c/src/pug/vue/photo-browser.pug#L86-L90

or `virtual-slides` ?)