### PR TITLE
Toggle: Fix missing closing tag

### DIFF
--- a/src/pug/docs/toggle.pug
+++ b/src/pug/docs/toggle.pug
@@ -34,6 +34,7 @@ block content
                   <span class="toggle-icon"></span>
                 </label>
               </li>
+            </ul>
           </div>
     p Inside of usual List (preferable in `item-after`):
     :code(lang="html")


### PR DESCRIPTION
Add missing closing tag in `Toggle` documentation.

https://github.com/framework7io/framework7-website/blob/861b1218762fb812a2e96fda133ed47c703152f2/src/pug/docs/toggle.pug#L27-L37