### PR TITLE
Range: Add missing properties

### DIFF
--- a/src/pug/docs/range-slider.pug
+++ b/src/pug/docs/range-slider.pug
@@ -253,6 +253,12 @@ block content
           td range.labels
           td Array where each element represent HTMLElement of created range knob label (2 labels in case of dual slider)
         tr
+          td range.vertical
+          td Boolean property indicating whether it is vertical or not
+        tr
+          td range.verticalReversed
+          td Boolean property indicating whether it is vertical and reversed or not
+        tr
           td range.params
           td Range Slider parameters
         tr


### PR DESCRIPTION
Adds missing `range.vertical` and `range.verticalReversed` properties that are declared in the TypeScript type definitions but aren't documented on the [website](https://framework7.io/docs/range-slider).