### PR TITLE
Updated Swiper default parameters in Photo Browser docs

### DIFF
--- a/src/pug/docs/photo-browser.pug
+++ b/src/pug/docs/photo-browser.pug
@@ -277,7 +277,7 @@ block content
               },
               {
                   url: 'image2.jpg',
-                  caption: 'Caption 1'
+                  caption: 'Second Caption'
               },
               // This one will be without caption
               {

--- a/src/pug/docs/photo-browser.pug
+++ b/src/pug/docs/photo-browser.pug
@@ -164,6 +164,9 @@ block content
                     speed: 300,
                     loop: false,
                     preloadImages: true,
+                    keyboard: {
+                      enabled: true,
+                    },
                     navigation: {
                       nextEl: '.photo-browser-next',
                       prevEl: '.photo-browser-prev',

--- a/src/pug/docs/photo-browser.pug
+++ b/src/pug/docs/photo-browser.pug
@@ -422,59 +422,59 @@ block content
         tr
           td tap
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user click/tap on Swiper. Receives 'touchend' event as an arguments.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user click/tap on Swiper. Receives 'touchend' event as an arguments.
         tr
           td click
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user click/tap on Swiper. Receives 'touchend' event as an arguments.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user click/tap on Swiper. Receives 'touchend' event as an arguments.
         tr
           td doubleTap
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user double tap on Swiper's container. Receives 'touchend' event as an arguments
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user double tap on Swiper's container. Receives 'touchend' event as an arguments
         tr
           td doubleClick
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user double tap on Swiper's container. Receives 'touchend' event as an arguments
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user double tap on Swiper's container. Receives 'touchend' event as an arguments
         tr
           td slideChange
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when currently active slide is changed
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when currently active slide is changed
         tr
           td transitionStart
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired in the beginning of transition.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired in the beginning of transition.
         tr
           td transitionEnd
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired after transition.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired after transition.
         tr
           td slideChangeTransitionStart
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired in the beginning of animation to other slide (next or previous).
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired in the beginning of animation to other slide (next or previous).
         tr
           td slideChangeTransitionEnd
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired after animation to other slide (next or previous).
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired after animation to other slide (next or previous).
         tr
           td lazyImageLoad
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired in the beginning of lazy loading of image
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired in the beginning of lazy loading of image
         tr
           td lazyImageReady
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when lazy loading image will be loaded
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when lazy loading image will be loaded
         tr
           td touchStart
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user touch Swiper. Receives 'touchstart' event as an arguments.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user touch Swiper. Receives 'touchstart' event as an arguments.
         tr
           td touchMoveOpposite
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user touch and move finger over Swiper in direction opposite to direction parameter. Receives 'touchmove' event as an arguments.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user touch and move finger over Swiper in direction opposite to direction parameter. Receives 'touchmove' event as an arguments.
         tr
           td touchEnd
           td photoBrowser
-          td <a href="https://swiperjs.com/api/#events" target="_blank">Swiper event</a>. Event will be fired when user release Swiper. Receives 'touchend' event as an arguments.
+          td <a href="https://swiperjs.com/swiper-api#events" target="_blank">Swiper event</a>. Event will be fired when user release Swiper. Receives 'touchend' event as an arguments.
 
         tr
           td open

--- a/src/pug/docs/photo-browser.pug
+++ b/src/pug/docs/photo-browser.pug
@@ -337,7 +337,7 @@ block content
           td Photo Browser View (that was passed in `view` parameter) or found parent view
         tr
           td photoBrowser.swiper
-          td Contains initialized Swiper instance with all available Swiper <a href="https://swiperjs.com/api/#methods" target="_blank">methods and properties</a>
+          td Contains initialized Swiper instance with all available Swiper <a href="https://swiperjs.com/swiper-api#methods-and-properties" target="_blank">methods and properties</a>
         tr
           td photoBrowser.params
           td Object with initialization parameters

--- a/src/pug/react/photo-browser.pug
+++ b/src/pug/react/photo-browser.pug
@@ -70,6 +70,9 @@ block content
                     speed: 300,
                     loop: false,
                     preloadImages: true,
+                    keyboard: {
+                      enabled: true,
+                    },
                     navigation: {
                       nextEl: '.photo-browser-next',
                       prevEl: '.photo-browser-prev',

--- a/src/pug/svelte/photo-browser.pug
+++ b/src/pug/svelte/photo-browser.pug
@@ -70,6 +70,9 @@ block content
                     speed: 300,
                     loop: false,
                     preloadImages: true,
+                    keyboard: {
+                      enabled: true,
+                    },
                     navigation: {
                       nextEl: '.photo-browser-next',
                       prevEl: '.photo-browser-prev',

--- a/src/pug/vue/photo-browser.pug
+++ b/src/pug/vue/photo-browser.pug
@@ -70,6 +70,9 @@ block content
                     speed: 300,
                     loop: false,
                     preloadImages: true,
+                    keyboard: {
+                      enabled: true,
+                    },
                     navigation: {
                       nextEl: '.photo-browser-next',
                       prevEl: '.photo-browser-prev',


### PR DESCRIPTION
Updated Swiper default parameters in Photo Browser docs

@nolimits4web Also perhaps it is appropriate to specify in the documentation that `cssMode` is now enabled by default for iOS and Android devices