### PR TITLE
Update migration-from-v7-to-v8.pug

### DIFF
--- a/src/pug/docs/migration-from-v7-to-v8.pug
+++ b/src/pug/docs/migration-from-v7-to-v8.pug
@@ -83,10 +83,10 @@ block content
     ul
       li By default list is rendered now without outline (borders), new `list-outline` class is required for that
       li By default list is rendered now without background, new `list-strong` class is required for that
-      li By default list is rendered now dividers (borders between list items), new `list-dividers` class is required for that
+      li By default list is rendered now without dividers (borders between list items), new `list-dividers` class is required for that
 
     h2 Card
     ul
       li By default card is rendered now without shadow, new `card-raised` class is required for that
-      li By default card is rendered now dividers (border) between card header and footer, new `card-header-divider` and `card-footer-divider` classes are required for that
+      li By default card is rendered now without dividers (border) between card header and footer, new `card-header-divider` and `card-footer-divider` classes are required for that
 


### PR DESCRIPTION
I think the word 'without' was missing from the descriptions