### PR TITLE
[v8] Re-added strong outline and dividers to lists in Docs Demos for iOS theme

### DIFF
--- a/src/pug/docs-demos/core/view-page-transitions.f7.html
+++ b/src/pug/docs-demos/core/view-page-transitions.f7.html
@@ -9,7 +9,7 @@
           </div>
         </div>
         <div class="page-content">
-          <div class="list links-list">
+          <div class="list list-strong-ios list-outline-ios list-dividers-ios links-list">
             <ul>
               <li><a href="/page-transitions/f7-circle" data-transition="f7-circle">f7-circle</a></li>
               <li><a href="/page-transitions/f7-cover" data-transition="f7-cover">f7-cover</a></li>

--- a/src/pug/docs/list-view.pug
+++ b/src/pug/docs/list-view.pug
@@ -209,7 +209,7 @@ block content
     h2 Links List
     p In case we need list with simple link items structure that have only titles, we may use Links List modification. In this case we need additional class `links-list` on list block with plain `<li><a>...</a></li>` items layout:
     :code(lang="html")
-          <div class="list links-list">
+          <div class="list list-strong-ios list-outline-ios list-dividers-ios links-list">
             <ul>
               <li>
                 <a href="#">Link Item 1</a>


### PR DESCRIPTION
[v8] Re-added strong outline and dividers to lists in Docs Demos for iOS theme