### PR TITLE
Correct store.getter access for users

### DIFF
--- a/src/pug/docs/store.pug
+++ b/src/pug/docs/store.pug
@@ -265,7 +265,7 @@ block content
       <script>
         export default (props, { $store, $on }) => {
           // retrieve "users" getter handler value. Initially empty array
-          const users = $store.getters('users');
+          const users = $store.getters.users;
 
           $on('pageInit', () => {
             // load users on page init


### PR DESCRIPTION
previous code was broken ('getters is not a function'), seems the docs are outdated in places